### PR TITLE
Fix quoting issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ curl -XPUT 'http://localhost:9200/searchguard/ac/ac' -d '{
         "filters_execute": []
      },
      {
-           "__Comment__": "For role 'admin' all filters are bypassed (so none will be executed). This means unrestricted access.",
+           "__Comment__": "For role *admin* all filters are bypassed (so none will be executed). This means unrestricted access.",
            "roles": [
                "admin"
            ],

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Why not install a ACL rules file which grants _all access_ for a user with role 
 curl -XPUT 'http://localhost:9200/searchguard/ac/ac' -d '{
     "acl": [
     {    
-        "__Comment__": "By default no filters are executed and no filters a by-passed. In such a case a exception is throws an access will be denied.",
+        "__Comment__": "By default no filters are executed and no filters a by-passed. In such a case an exception is thrown and access will be denied.",
         "filters_bypass": [],
         "filters_execute": []
      },


### PR DESCRIPTION
Remove single quotes from inside a single-quoted string.  Otherwise, if someone were to copy and paste the `curl` command as is, it would fail.