### PR TITLE
Security config log message to debug, readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ If you use either transport layer SSL or DLS or FLS you have to install it on ev
 TBD
 
 ##Auditlog
-Auditlog is stored in Elasticsearch withing the _searchguard_ index (with type _audit_)<br>
+Auditlog is stored in Elasticsearch within the _searchguard_ index (with type _audit_)<br>
 ``curl -XGET 'http://localhost:9200/searchguard/audit/_search?pretty=true'``
 
 ##Rules evaluation 
@@ -323,7 +323,7 @@ If you access more than one index (e.g. search in multiple indices) only rules w
 {       
     "roles": [...],
     "indices": [
-         „finance","marketing"
+         "finance","marketing"
     ],
     "filters_bypass": [...],
     "filters_execute": [...]

--- a/src/main/java/com/floragunn/searchguard/service/SearchGuardConfigService.java
+++ b/src/main/java/com/floragunn/searchguard/service/SearchGuardConfigService.java
@@ -86,7 +86,7 @@ public class SearchGuardConfigService extends AbstractLifecycleComponent<SearchG
                 if (response.isExists() && !response.isSourceEmpty()) {
                     securityConfiguration = response.getSourceAsBytesRef();
                     latch.countDown();
-                    logger.info("Security configuration reloaded");
+                    logger.debug("Security configuration reloaded");
 
                 }
             }


### PR DESCRIPTION
A couple typo fixes for the `README` as well as changing the log level for the `Security configuration reloaded` message to `DEBUG`.