### PR TITLE
Handling exceptions to address #61

### DIFF
--- a/src/main/java/com/floragunn/searchguard/service/SearchGuardConfigService.java
+++ b/src/main/java/com/floragunn/searchguard/service/SearchGuardConfigService.java
@@ -28,6 +28,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.NoShardAvailableActionException;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
@@ -94,7 +95,7 @@ public class SearchGuardConfigService extends AbstractLifecycleComponent<SearchG
 
             @Override
             public void onFailure(final Throwable e) {
-                if (e instanceof IndexMissingException || e instanceof NoShardAvailableActionException) {
+                if (e instanceof IndexMissingException || e instanceof NoShardAvailableActionException || e instanceof ClusterBlockException) {
                     logger.debug(
                             "Try to refresh security configuration but it failed due to {} - This might be ok if security setup not complete yet.",
                             e.toString());

--- a/src/main/java/com/floragunn/searchguard/service/SearchGuardConfigService.java
+++ b/src/main/java/com/floragunn/searchguard/service/SearchGuardConfigService.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.NoShardAvailableActionException;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -93,7 +94,7 @@ public class SearchGuardConfigService extends AbstractLifecycleComponent<SearchG
 
             @Override
             public void onFailure(final Throwable e) {
-                if (e instanceof IndexMissingException) {
+                if (e instanceof IndexMissingException || e instanceof NoShardAvailableActionException) {
                     logger.debug(
                             "Try to refresh security configuration but it failed due to {} - This might be ok if security setup not complete yet.",
                             e.toString());


### PR DESCRIPTION
Catching two exceptions that can occur when starting up concurrently with ElasticSearch that imply that it has not fully started up yet.

@floragunncom PTAL