### PR TITLE
Enable encryption of properties in the yml file.

### DIFF
--- a/src/main/java/com/floragunn/searchguard/AuthModule.java
+++ b/src/main/java/com/floragunn/searchguard/AuthModule.java
@@ -17,6 +17,8 @@
 
 package com.floragunn.searchguard;
 
+import com.floragunn.searchguard.property.SettingsBasedPropertyResolverImpl;
+import com.floragunn.searchguard.property.PropertyResolver;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.settings.Settings;
 
@@ -57,6 +59,11 @@ public final class AuthModule extends AbstractModule {
         final Class<? extends NonCachingAuthenticationBackend> defaultNonCachingAuthenticationBackend = SettingsBasedAuthenticationBackend.class;
         final Class<? extends HTTPAuthenticator> defaultHTTPAuthenticator = HTTPBasicAuthenticator.class;
         final Class<? extends NonCachingAuthorizator> defaultNonCachingAuthorizator = SettingsBasedAuthorizator.class;
+		final Class<? extends PropertyResolver> defaultPropertyResolver = SettingsBasedPropertyResolverImpl.class;
+
+		final Class<? extends PropertyResolver> propertyResolver = settings.getAsClass(
+			ConfigConstants.SEARCHGUARD_PROPERTY_PROPERTY_RESOLVER_IMPL, defaultPropertyResolver);
+		bind(PropertyResolver.class).to(propertyResolver).asEagerSingleton();
 
         final Class<? extends NonCachingAuthenticationBackend> authenticationBackend = settings.getAsClass(
                 ConfigConstants.SEARCHGUARD_AUTHENTICATION_AUTHENTICATION_BACKEND, defaultNonCachingAuthenticationBackend);

--- a/src/main/java/com/floragunn/searchguard/property/PropertyResolver.java
+++ b/src/main/java/com/floragunn/searchguard/property/PropertyResolver.java
@@ -1,0 +1,10 @@
+package com.floragunn.searchguard.property;
+
+import org.elasticsearch.common.settings.Settings;
+
+/**
+ * Created by ORENKAF on 12/30/2015.
+ */
+public interface PropertyResolver {
+	String getProperty(String propertyName, String defaultValue);
+}

--- a/src/main/java/com/floragunn/searchguard/property/SettingsBasedPropertyResolverImpl.java
+++ b/src/main/java/com/floragunn/searchguard/property/SettingsBasedPropertyResolverImpl.java
@@ -1,0 +1,23 @@
+package com.floragunn.searchguard.property;
+
+import com.floragunn.searchguard.util.ConfigConstants;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+
+/**
+ * Created by ORENKAF on 12/30/2015.
+ */
+public class SettingsBasedPropertyResolverImpl implements PropertyResolver {
+
+	private final Settings settings;
+
+	@Inject
+	public SettingsBasedPropertyResolverImpl(final Settings settings) {
+		this.settings = settings;
+	}
+
+	@Override
+	public String getProperty(String propertyName, String defaultValue) {
+		return settings.get(propertyName, defaultValue);
+	}
+}

--- a/src/main/java/com/floragunn/searchguard/service/SearchGuardService.java
+++ b/src/main/java/com/floragunn/searchguard/service/SearchGuardService.java
@@ -26,6 +26,7 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
+import com.floragunn.searchguard.property.PropertyResolver;
 import org.apache.commons.io.FileUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.client.Client;
@@ -72,12 +73,18 @@ public class SearchGuardService extends AbstractLifecycleComponent<SearchGuardSe
 
     private final SessionStore sessionStore;
 
+	private final PropertyResolver propertyResolver;
+
     public Authorizator getAuthorizator() {
         return authorizator;
     }
 
     public AuthenticationBackend getAuthenticationBackend() {
         return authenticationBackend;
+    }
+
+	public PropertyResolver getPropertyResolver() {
+		return propertyResolver;
     }
 
     public HTTPAuthenticator getHttpAuthenticator() {
@@ -96,7 +103,8 @@ public class SearchGuardService extends AbstractLifecycleComponent<SearchGuardSe
     @Inject
     public SearchGuardService(final Settings settings, final RestController restController, final Client client,
             final Authorizator authorizator, final AuthenticationBackend authenticationBackend, final HTTPAuthenticator httpAuthenticator,
-            final SessionStore sessionStore, final AuditListener auditListener, final SearchService searchService) {
+            final SessionStore sessionStore, final AuditListener auditListener, final SearchService searchService,
+			final PropertyResolver propertyResolver) {
         super(settings);
         this.restController = restController;
         this.client = client;
@@ -107,6 +115,7 @@ public class SearchGuardService extends AbstractLifecycleComponent<SearchGuardSe
         this.authorizator = authorizator;
         this.httpAuthenticator = httpAuthenticator;
         this.sessionStore = sessionStore;
+		this.propertyResolver = propertyResolver;
 
         try {
             method = RestController.class.getDeclaredMethod("getHandler", RestRequest.class);

--- a/src/main/java/com/floragunn/searchguard/util/ConfigConstants.java
+++ b/src/main/java/com/floragunn/searchguard/util/ConfigConstants.java
@@ -89,6 +89,9 @@ public final class ConfigConstants {
     public static final String SEARCHGUARD_SSL_TRANSPORT_NODE_TRUSTSTORE_TYPE = "searchguard.ssl.transport.node.truststore_type";
     public static final String SEARCHGUARD_WAFFLE_WINDOWS_AUTH_PROVIDER_IMPL = "searchguard.waffle.windows_auth_provider_impl";
 
+	public static final String SEARCHGUARD_PROPERTY_PROPERTY_RESOLVER_IMPL = "searchguard.property.property_resolver.impl";
+
+
     private ConfigConstants() {
 
     }


### PR DESCRIPTION
Hi,
We are from Amdocs company and using search guard plugin for elastic search in our project.
As part of our security penetration tests made in our company, an issue was raised regarding plain text passwords in the yml file.
Due to that, we made few changes in search guard code which enables encryption of properties in the yml file.
We would like to contribute this code and hopefully get it as part of your upcoming releases, please advise if there is any formal way to do it.

The fix contains the below changes:
1)	A general mechanism which enables to parse any search guard property in a custom code. 
2)	Currently truststore_password & keystore_password are parsed with the new mechanism. Rest of the properties can be implemented as well.
3)	New key in YML file which indicates the custom class ‘searchguard.property.property_resolver.impl’ (i.e. searchguard.property.property_resolver.impl: com.amdocs.bda.searchguard.BDAPropertyResolverImpl)
4)	In case of not defining the key in YML, SettingsBasedPropertyResolverImpl will be used as a default implementation which keeps the same behavior as before, meaning that values of the properties will be loaded regularly from YML file


Classes that were changed:
•	PropertyResolver – new interface
•	SettingsBasedPropertyResolverImpl – new class
•	AuthModule – modified class
•	ConfigConstants – modified class
•	SearchGuardService – modified class
•	SSLNettyHttpServerTransport – modified class
