### PR TITLE
Support configurable OID

### DIFF
--- a/sgconfig/elasticsearch.yml.example
+++ b/sgconfig/elasticsearch.yml.example
@@ -39,3 +39,6 @@ searchguard.audit.type: internal_elasticsearch
 # The relative path to config/ directory
 # to the keytab where the acceptor_principal credentials are stored.
 #searchguard.kerberos.acceptor_keytab_filepath: 'eskeytab.tab'
+
+# This defines the OID of node certificates
+#searchguard.cert.oid: '1.2.3.4.5.5'

--- a/src/main/java/com/floragunn/searchguard/transport/SearchGuardTransportService.java
+++ b/src/main/java/com/floragunn/searchguard/transport/SearchGuardTransportService.java
@@ -60,6 +60,7 @@ public class SearchGuardTransportService extends SearchGuardSSLTransportService 
     protected final ESLogger log = Loggers.getLogger(this.getClass());
     private final Provider<BackendRegistry> backendRegistry;
     private final AuditLog auditLog;
+    private final String certOid;
 
     @Inject
     public SearchGuardTransportService(final Settings settings, final Transport transport, final ThreadPool threadPool,
@@ -67,6 +68,7 @@ public class SearchGuardTransportService extends SearchGuardSSLTransportService 
         super(settings, transport, threadPool);
         this.backendRegistry = backendRegistry;
         this.auditLog = auditLog;
+        this.certOid = settings.get("searchguard.cert.oid", "1.2.3.4.5.5");
     }
 
     @Override
@@ -150,7 +152,7 @@ public class SearchGuardTransportService extends SearchGuardSSLTransportService 
                 }
             }
 
-            if (sb.indexOf("8::1.2.3.4.5.5") >= 0) {
+            if (sb.indexOf("8::" + this.certOid) >= 0) {
                 isInterClusterRequest = true;
             }
 


### PR DESCRIPTION
Currently the OID is hardcoded as '1.2.3.4.5.5'.
This patch enables to specify custom OID value.

References:
https://github.com/floragunncom/search-guard/issues/92
https://groups.google.com/forum/#!msg/search-guard/LJkXQACXzL0/0RKfXwpJLAAJ