### PR TITLE
Use username variable at indices sections in sg_roles.yml

### DIFF
--- a/sgconfig/sg_roles.yml
+++ b/sgconfig/sg_roles.yml
@@ -180,6 +180,6 @@ sg_logstash:
 # Allows each user to access own named index
 sg_ownindex:
   indices:
-    '%{user_name}':
+    '${user_name}':
       '*':
         - ALL

--- a/sgconfig/sg_roles.yml
+++ b/sgconfig/sg_roles.yml
@@ -176,3 +176,10 @@ sg_logstash:
       '*':
         - CRUD
         - CREATE_INDEX
+
+# Allows each user to access own named index
+sg_ownindex:
+  indices:
+    '%{user_name}':
+      '*':
+        - ALL

--- a/sgconfig/sg_roles.yml
+++ b/sgconfig/sg_roles.yml
@@ -178,7 +178,7 @@ sg_logstash:
         - CREATE_INDEX
 
 # Allows each user to access own named index
-sg_ownindex:
+sg_own_index:
   indices:
     '${user_name}':
       '*':

--- a/sgconfig/sg_roles_mapping.yml
+++ b/sgconfig/sg_roles_mapping.yml
@@ -59,6 +59,6 @@ sg_kibana4_testindex:
   users:
     - test
 
-sg_ownindex:
+sg_own_index:
   users:
     - '*'

--- a/sgconfig/sg_roles_mapping.yml
+++ b/sgconfig/sg_roles_mapping.yml
@@ -57,4 +57,8 @@ sg_readonly_dlsfls:
     
 sg_kibana4_testindex:
   users:
-    - test    
+    - test
+
+sg_ownindex:
+  users:
+    - '*'

--- a/src/main/java/com/floragunn/searchguard/configuration/PrivilegesEvaluator.java
+++ b/src/main/java/com/floragunn/searchguard/configuration/PrivilegesEvaluator.java
@@ -706,10 +706,8 @@ public class PrivilegesEvaluator implements ConfigChangeListener {
         for (String index : indices.keySet()) {
             String replacedIndex = index.replace(variableName, value);
             replacedIndices.put(replacedIndex, indices.get(index));
-            if (log.isDebugEnabled()) {
-                if (!replacedIndex.equals(index)) {
-                    log.debug("Index '{}' was replaced with '{}'", index, replacedIndex);
-                }
+            if (log.isDebugEnabled() && !replacedIndex.equals(index)) {
+                log.debug("Index '{}' was replaced with '{}'", index, replacedIndex);
             }
         }
         return replacedIndices;

--- a/src/main/java/com/floragunn/searchguard/configuration/PrivilegesEvaluator.java
+++ b/src/main/java/com/floragunn/searchguard/configuration/PrivilegesEvaluator.java
@@ -265,7 +265,7 @@ public class PrivilegesEvaluator implements ConfigChangeListener {
                 }
             }
 
-            final Map<String, Settings> permittedAliasesIndices = sgRoleSettings.getGroups(".indices");
+            final Map<String, Settings> permittedAliasesIndices = replaceIndicesVariable(sgRoleSettings.getGroups(".indices"), "%{user_name}", user.getName());
 
             /*
             sg_role_starfleet:
@@ -699,5 +699,19 @@ public class PrivilegesEvaluator implements ConfigChangeListener {
         }
 
         return resolvedActions;
+    }
+
+    private Map<String, Settings> replaceIndicesVariable(Map<String, Settings> indices, String variableName, String value) {
+        Map<String, Settings> replacedIndices = new HashMap<String, Settings>();
+        for (String index : indices.keySet()) {
+            String replacedIndex = index.replace(variableName, value);
+            replacedIndices.put(replacedIndex, indices.get(index));
+            if (log.isDebugEnabled()) {
+                if (!replacedIndex.equals(index)) {
+                    log.debug("Index '{}' was replaced with '{}'", index, replacedIndex);
+                }
+            }
+        }
+        return replacedIndices;
     }
 }

--- a/src/test/java/com/floragunn/searchguard/SGTests.java
+++ b/src/test/java/com/floragunn/searchguard/SGTests.java
@@ -406,6 +406,9 @@ public class SGTests extends AbstractUnitTest {
             tc.index(new IndexRequest("public").type("hall_of_fame").refresh(true).source("{\"content\":1}")).actionGet();
             tc.index(new IndexRequest("public").type("hall_of_fame").refresh(true).source("{\"content\":2}")).actionGet();
             
+            tc.index(new IndexRequest("spock").type("type01").refresh(true).source("{\"content\":1}")).actionGet();
+            tc.index(new IndexRequest("kirk").type("type01").refresh(true).source("{\"content\":1}")).actionGet();
+
             tc.admin().indices().aliases(new IndicesAliasesRequest().addAlias("sf", "starfleet","starfleet_academy","starfleet_library")).actionGet();
             tc.admin().indices().aliases(new IndicesAliasesRequest().addAlias("nonsf", "klingonempire","vulcangov")).actionGet();
             tc.admin().indices().aliases(new IndicesAliasesRequest().addAlias("unrestricted", "public")).actionGet();
@@ -456,6 +459,10 @@ public class SGTests extends AbstractUnitTest {
         HttpResponse resc = executeGetRequest("_cat/indices/public",new BasicHeader("Authorization", "Basic "+encodeBasicHeader("bug108", "nagilum")));
         Assert.assertTrue(resc.getBody().contains("green"));
         Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+
+        Assert.assertEquals(HttpStatus.SC_OK, executeGetRequest("spock/type01/_search?pretty",new BasicHeader("Authorization", "Basic "+encodeBasicHeader("spock", "spock"))).getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, executeGetRequest("spock/type01/_search?pretty",new BasicHeader("Authorization", "Basic "+encodeBasicHeader("kirk", "kirk"))).getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_OK, executeGetRequest("kirk/type01/_search?pretty",new BasicHeader("Authorization", "Basic "+encodeBasicHeader("kirk", "kirk"))).getStatusCode());
         
         
 //all
@@ -490,7 +497,7 @@ public class SGTests extends AbstractUnitTest {
         Assert.assertEquals(HttpStatus.SC_OK, executeGetRequest("starfleet/ships/_search?pretty", new BasicHeader("Authorization", "Basic "+encodeBasicHeader("worf", "worf"))).getStatusCode());
         HttpResponse res = executeGetRequest("_search?pretty", new BasicHeader("Authorization", "Basic "+encodeBasicHeader("nagilum", "nagilum")));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-        Assert.assertTrue(res.getBody().contains("\"total\" : 15"));
+        Assert.assertTrue(res.getBody().contains("\"total\" : 17"));
         Assert.assertTrue(!res.getBody().contains("searchguard"));
         
         res = executeGetRequest("_nodes/stats?pretty", new BasicHeader("Authorization", "Basic "+encodeBasicHeader("nagilum", "nagilum")));

--- a/src/test/resources/sg_roles.yml
+++ b/src/test/resources/sg_roles.yml
@@ -195,3 +195,9 @@ sg_theindex_admin:
     theindex:
       '*':
         - ALL
+
+sg_own_index:
+  indices:
+    '${user_name}':
+      '*':
+        - ALL

--- a/src/test/resources/sg_roles_mapping.yml
+++ b/src/test/resources/sg_roles_mapping.yml
@@ -72,3 +72,8 @@ sg_role_host2:
 sg_theindex_admin:
   users:
     - theindexadmin
+
+sg_own_index:
+  users:
+    - spock
+    - kirk


### PR DESCRIPTION
In the case that each user has own index and these indices allow access only from the owner, currently, an admin has to define the permissions in sg_roles.yml and sg_roles_mapping.yml for every user. And whenever new user is registered, the admin has to add an permission for the person.

This patch enables to set username variable at indices sections in sg_roles.yml and releases the admin from the troublesome task.