### PR TITLE
Support and_backendroles

### DIFF
--- a/src/main/java/com/floragunn/searchguard/configuration/PrivilegesEvaluator.java
+++ b/src/main/java/com/floragunn/searchguard/configuration/PrivilegesEvaluator.java
@@ -548,6 +548,11 @@ public class PrivilegesEvaluator implements ConfigChangeListener {
         final Set<String> sgRoles = new TreeSet<String>();
         for (final String roleMap : rolesMapping.names()) {
             final Settings roleMapSettings = rolesMapping.getByPrefix(roleMap);
+            if (WildcardMatcher.matchAllPatterns(roleMapSettings.getAsArray(".and_backendroles"), user.getRoles().toArray(new String[0]))) {
+                sgRoles.add(roleMap);
+                continue;
+            }
+
             if (WildcardMatcher.matchAny(roleMapSettings.getAsArray(".backendroles"), user.getRoles().toArray(new String[0]))) {
                 sgRoles.add(roleMap);
                 continue;

--- a/src/main/java/com/floragunn/searchguard/support/WildcardMatcher.java
+++ b/src/main/java/com/floragunn/searchguard/support/WildcardMatcher.java
@@ -47,6 +47,20 @@ public class WildcardMatcher {
         return true;
     }
 
+    public static boolean matchAllPatterns(final String[] pattern, final String[] candidate) {
+
+        int matchedPatternNum = 0;
+
+        for (int i = 0; i < pattern.length; i++) {
+            final String string = pattern[i];
+            if (matchAny(string, candidate)) {
+                matchedPatternNum++;
+            }
+        }
+
+        return matchedPatternNum == pattern.length && pattern.length > 0;
+    }
+
     public static boolean matchAny(final String pattern, final String[] candidate) {
 
         for (int i = 0; i < candidate.length; i++) {

--- a/src/test/java/com/floragunn/searchguard/SGTests.java
+++ b/src/test/java/com/floragunn/searchguard/SGTests.java
@@ -409,6 +409,8 @@ public class SGTests extends AbstractUnitTest {
             tc.index(new IndexRequest("spock").type("type01").refresh(true).source("{\"content\":1}")).actionGet();
             tc.index(new IndexRequest("kirk").type("type01").refresh(true).source("{\"content\":1}")).actionGet();
 
+            tc.index(new IndexRequest("role01_role02").type("type01").refresh(true).source("{\"content\":1}")).actionGet();
+
             tc.admin().indices().aliases(new IndicesAliasesRequest().addAlias("sf", "starfleet","starfleet_academy","starfleet_library")).actionGet();
             tc.admin().indices().aliases(new IndicesAliasesRequest().addAlias("nonsf", "klingonempire","vulcangov")).actionGet();
             tc.admin().indices().aliases(new IndicesAliasesRequest().addAlias("unrestricted", "public")).actionGet();
@@ -463,6 +465,9 @@ public class SGTests extends AbstractUnitTest {
         Assert.assertEquals(HttpStatus.SC_OK, executeGetRequest("spock/type01/_search?pretty",new BasicHeader("Authorization", "Basic "+encodeBasicHeader("spock", "spock"))).getStatusCode());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, executeGetRequest("spock/type01/_search?pretty",new BasicHeader("Authorization", "Basic "+encodeBasicHeader("kirk", "kirk"))).getStatusCode());
         Assert.assertEquals(HttpStatus.SC_OK, executeGetRequest("kirk/type01/_search?pretty",new BasicHeader("Authorization", "Basic "+encodeBasicHeader("kirk", "kirk"))).getStatusCode());
+
+        Assert.assertEquals(HttpStatus.SC_OK, executeGetRequest("role01_role02/type01/_search?pretty",new BasicHeader("Authorization", "Basic "+encodeBasicHeader("user_role01_role02_role03", "user_role01_role02_role03"))).getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, executeGetRequest("role01_role02/type01/_search?pretty",new BasicHeader("Authorization", "Basic "+encodeBasicHeader("user_role01", "user_role01"))).getStatusCode());
         
         
 //all
@@ -497,7 +502,7 @@ public class SGTests extends AbstractUnitTest {
         Assert.assertEquals(HttpStatus.SC_OK, executeGetRequest("starfleet/ships/_search?pretty", new BasicHeader("Authorization", "Basic "+encodeBasicHeader("worf", "worf"))).getStatusCode());
         HttpResponse res = executeGetRequest("_search?pretty", new BasicHeader("Authorization", "Basic "+encodeBasicHeader("nagilum", "nagilum")));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-        Assert.assertTrue(res.getBody().contains("\"total\" : 17"));
+        Assert.assertTrue(res.getBody().contains("\"total\" : 18"));
         Assert.assertTrue(!res.getBody().contains("searchguard"));
         
         res = executeGetRequest("_nodes/stats?pretty", new BasicHeader("Authorization", "Basic "+encodeBasicHeader("nagilum", "nagilum")));

--- a/src/test/resources/sg_internal_users.yml
+++ b/src/test/resources/sg_internal_users.yml
@@ -76,3 +76,15 @@ writer:
   hash: $2a$12$LZvbDVnegkTbEFTu9hHnWO4HIrdB9rGaKcEOID5n0VV4j58cnvyZ.
 dlsnoinvest:
   hash: $2a$12$9Zr4IgoJRqK6xJq4xjoa6OZAnY4QOQ6xIhcCxeYoQtB/HriMkeJSC
+user_role01:
+  hash: $2a$12$XrBfLQh2T8wIzpxE5vzhUOPjjGfONcD8UEjd5IT5KveG8ULZaj04.
+  # password is: user_role01
+  roles:
+    - role01
+user_role01_role02_role03:
+  hash: $2a$12$6.4Y6L//xeKQ7t8YEG0s6OH4F4q9gMw0J8E0GjmUMNZeyIWu1IRWS
+  # password is: user_role01_role02_role03
+  roles:
+    - role01
+    - role02
+    - role03

--- a/src/test/resources/sg_roles.yml
+++ b/src/test/resources/sg_roles.yml
@@ -259,3 +259,9 @@ sg_dlsnoinvest:
       '*':
         - ALL
       _dls_: '{"term" : {"category_code" : "software"}}'
+
+sg_role01_role02:
+  indices:
+    'role01_role02':
+      '*':
+        - ALL

--- a/src/test/resources/sg_roles_mapping.yml
+++ b/src/test/resources/sg_roles_mapping.yml
@@ -101,3 +101,8 @@ sg_writer:
 sg_dlsnoinvest:
   users:
     - dlsnoinvest
+
+sg_role01_role02:
+  and_backendroles:
+    - role01
+    - role02


### PR DESCRIPTION
This patch covers the following situation:
 - there is an index and it only allows access from users belonging to both role01 and role02 backendroles
 - a user on role01 or role02 either cannot access the index

Related issue: https://github.com/floragunncom/search-guard/issues/243

Usage:
```
sg_role01_role02:
  and_backendroles:
   - role01
   - role02
```