### PR TITLE
Provide mechanism to override the default interclusterrequest evaluation

### DIFF
--- a/sgconfig/elasticsearch.yml.example
+++ b/sgconfig/elasticsearch.yml.example
@@ -52,3 +52,10 @@ searchguard.audit.type: internal_elasticsearch
 # If you set wrong values here this this could be a security risk
 # or make Search Guard stop working
 #searchguard.cert.oid: '1.2.3.4.5.5'
+
+# This specifies the implementation of com.floragunn.searchguard.transport.InterClusterRequestEvaluator
+# that is used to determine inter cluster message.  The default is to use the oid value of 'searchguard.cert.oid'
+# as described: https://github.com/floragunncom/search-guard-docs/blob/master/architecture.md
+# Instance of com.floragunn.searchguard.transport.InterClusterRequestEvaluator must implement a single arg
+# constructor that takes a org.elasticsearch.common.settings.Settings
+#searchguard.cert.intercluster_request_evaluator: com.floragunn.searchguard.transport.DefaultInterClusterRequestEvaluator

--- a/src/main/java/com/floragunn/searchguard/configuration/ConfigurationModule.java
+++ b/src/main/java/com/floragunn/searchguard/configuration/ConfigurationModule.java
@@ -23,6 +23,8 @@ import org.elasticsearch.common.logging.Loggers;
 
 import com.floragunn.searchguard.auth.internal.InternalAuthenticationBackend;
 import com.floragunn.searchguard.configuration.DlsFlsRequestValve.NoopDlsFlsRequestValve;
+import com.floragunn.searchguard.transport.InterClusterRequestEvaluator;
+import com.floragunn.searchguard.transport.InterClusterRequestEvaluatorProvider;
 
 public class ConfigurationModule extends AbstractModule {
 
@@ -36,6 +38,9 @@ public class ConfigurationModule extends AbstractModule {
         bind(ActionGroupHolder.class).asEagerSingleton();
         bind(PrivilegesEvaluator.class).asEagerSingleton();
         bind(InternalAuthenticationBackend.class).asEagerSingleton();
+        bind(InterClusterRequestEvaluator.class)
+            .toProvider(InterClusterRequestEvaluatorProvider.class)
+            .asEagerSingleton();
         
         try {
             Class dlsFlsRequestValve;
@@ -52,4 +57,6 @@ public class ConfigurationModule extends AbstractModule {
         }
                
     }
+    
+    
 }

--- a/src/main/java/com/floragunn/searchguard/transport/DefaultInterClusterRequestEvaluator.java
+++ b/src/main/java/com/floragunn/searchguard/transport/DefaultInterClusterRequestEvaluator.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017 floragunn UG (haftungsbeschränkt)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.floragunn.searchguard.transport;
+
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.transport.TransportRequest;
+
+public class DefaultInterClusterRequestEvaluator implements InterClusterRequestEvaluator {
+
+    private final ESLogger log = Loggers.getLogger(this.getClass());
+    private final String certOid;
+    
+    public DefaultInterClusterRequestEvaluator(final Settings settings) {
+        this.certOid = settings.get("searchguard.cert.oid", "1.2.3.4.5.5");
+    }
+
+    @Override
+    public boolean isInterClusterRequest(TransportRequest request, X509Certificate[] localCerts, X509Certificate[] peerCerts) {
+        try {
+            final Collection<List<?>> ianList = peerCerts[0].getSubjectAlternativeNames();
+            if (ianList != null) {
+                final StringBuilder sb = new StringBuilder();
+                
+                for (final List<?> ian : ianList) {
+                    
+                    if (ian == null) {
+                        continue;
+                    }
+                    
+                    for (@SuppressWarnings("rawtypes")
+                    final Iterator iterator = ian.iterator(); iterator.hasNext();) {
+                        final int id = (int) iterator.next();
+                        if (id == 8) { //id 8 = OID, id 1 = name (as string or ASN.1 encoded byte[])
+                            Object value = iterator.next();
+                            
+                            if(value == null) {
+                                continue;
+                            }
+                            
+                            if(value instanceof String) {
+                                sb.append(id + "::" + value);
+                            } else if(value instanceof byte[]) {
+                                log.error("Unable to handle OID san {} with value {} of type byte[] (ASN.1 DER not supported here)", id, Arrays.toString((byte[]) value));
+                            } else {
+                                log.error("Unable to handle OID san {} with value {} of type {}", id, value, value.getClass());
+                            }
+                        } else {
+                            iterator.next();
+                        }
+                    }
+                }
+                
+                if (sb.indexOf("8::" + this.certOid) >= 0) {
+                    return true;
+                }
+                
+            } else {
+                if (log.isTraceEnabled()) {
+                    log.trace("No subject alternative names (san) found");
+                }
+            }
+        }catch(CertificateParsingException e) {
+            if(log.isDebugEnabled()) {
+                log.debug("Exception parsing certificate using {}", e, this.getClass());
+            }
+            throw new ElasticsearchException(e);
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/com/floragunn/searchguard/transport/InterClusterRequestEvaluator.java
+++ b/src/main/java/com/floragunn/searchguard/transport/InterClusterRequestEvaluator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 floragunn UG (haftungsbeschränkt)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.floragunn.searchguard.transport;
+
+import java.security.cert.X509Certificate;
+
+import org.elasticsearch.transport.TransportRequest;
+
+/**
+ * Evaluates a request to determine if it is
+ * intercluster communication.  Implementations
+ * should include a single arg constructor that
+ * takes org.elasticsearch.common.settings.Settings
+ *
+ */
+public interface InterClusterRequestEvaluator {
+
+    /**
+     * Determine if request is a message from
+     * another node in the cluster
+     * 
+     * @param   request     The transport request to evaluate
+     * @param   localCerts  Local certs to use for evaluating the request which include criteria
+     *                      specific to the implementation for confirming intercluster
+     *                      communication
+     *                      
+     * @param   peerCerts       Certs to use for evaluating the request which include criteria
+     *                      specific to the implementation for confirming intercluster
+     *                      communication
+     *                      
+     * @return True when determined to be intercluster, false otherwise
+     */
+    boolean isInterClusterRequest(final TransportRequest request, final X509Certificate[] localCerts, final X509Certificate[] peerCerts);
+}

--- a/src/main/java/com/floragunn/searchguard/transport/InterClusterRequestEvaluatorProvider.java
+++ b/src/main/java/com/floragunn/searchguard/transport/InterClusterRequestEvaluatorProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 floragunn UG (haftungsbeschränkt)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.floragunn.searchguard.transport;
+
+import java.lang.reflect.Constructor;
+
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Provider;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+
+public class InterClusterRequestEvaluatorProvider implements Provider<InterClusterRequestEvaluator> {
+
+    static final String KEY = "searchguard.cert.intercluster_request_evaluator";
+    private final ESLogger log = Loggers.getLogger(this.getClass());
+    private InterClusterRequestEvaluator evaluator;
+    
+    @Inject
+    public InterClusterRequestEvaluatorProvider(final Settings settings) {
+        final String className = settings.get(KEY, DefaultInterClusterRequestEvaluator.class.getName());
+        log.info("Using {} ", className);
+        if(!className.equals(DefaultInterClusterRequestEvaluator.class.getName())) {
+            try {
+                Class<?> klass = Class.forName(className);
+                Constructor<?> constructor = klass.getConstructor(Settings.class);
+                evaluator =  (InterClusterRequestEvaluator) constructor.newInstance(settings);
+                return;
+            }catch(Exception e) {
+                log.warn("Using DefaultInterClusterRequestEvaluator. Unable to instantiate {} ", e, className);
+                if(log.isTraceEnabled()) {
+                    log.trace("Unable to instantiate InterClusterRequestEvaluator", e);
+                }
+            }
+        }
+        evaluator = new DefaultInterClusterRequestEvaluator(settings);
+    }
+    
+    @Override
+    public InterClusterRequestEvaluator get() {
+        return evaluator;
+    }
+    
+}

--- a/src/main/java/com/floragunn/searchguard/transport/OIDClusterRequestEvaluator.java
+++ b/src/main/java/com/floragunn/searchguard/transport/OIDClusterRequestEvaluator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 floragunn UG (haftungsbeschränkt)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.floragunn.searchguard.transport;
+
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.transport.TransportRequest;
+
+/**
+ * Implementation to evaluate a certificate extension with a given OID
+ * and value to the same value found on the peer certificate
+ *
+ */
+public class OIDClusterRequestEvaluator implements InterClusterRequestEvaluator {
+    private final ESLogger log = Loggers.getLogger(this.getClass());
+    private final String certOid;
+    
+    public OIDClusterRequestEvaluator(final Settings settings) {
+        this.certOid = settings.get("searchguard.cert.oid", "1.2.3.4.5.5");
+    }
+    
+    @Override
+    public boolean isInterClusterRequest(TransportRequest request, X509Certificate[] localCerts, X509Certificate[] peerCerts) {
+        if(localCerts != null && localCerts.length >0 && peerCerts != null && peerCerts.length >0) {
+            final byte[] localValue = localCerts[0].getExtensionValue(certOid);
+            final byte[] peerValue = peerCerts[0].getExtensionValue(certOid);
+            if(localValue != null && peerValue != null) {
+                return Arrays.equals(localValue, peerValue);
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/test/java/com/floragunn/searchguard/transport/InterClusterRequestEvaluatorProviderTest.java
+++ b/src/test/java/com/floragunn/searchguard/transport/InterClusterRequestEvaluatorProviderTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 floragunn UG (haftungsbeschränkt)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.floragunn.searchguard.transport;
+
+import static org.junit.Assert.*;
+
+import java.security.cert.X509Certificate;
+
+import org.elasticsearch.common.inject.Provider;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.Settings.Builder;
+import org.elasticsearch.transport.TransportRequest;
+import org.junit.Test;
+
+public class InterClusterRequestEvaluatorProviderTest {
+
+    private Settings settings;
+    private Provider<InterClusterRequestEvaluator> provider;
+    
+    @Test
+    public void testUsesDefaultWhenSettingIsMissing() {
+        givenImplIs(null);
+        provider = new InterClusterRequestEvaluatorProvider(settings);
+        assertTrue("Exp. to use default evaluator when setting is missing", provider.get() instanceof DefaultInterClusterRequestEvaluator);
+    }
+    
+    @Test
+    public void testUsesDefaultWhenImplCantBeLoaded() {
+        givenImplIs("java.lang.String");
+        provider = new InterClusterRequestEvaluatorProvider(settings);
+        assertTrue("Exp. to use default evaluator when implementation can not be loaded", provider.get() instanceof DefaultInterClusterRequestEvaluator);
+    }
+
+    @Test
+    public void testLoadsCustomEvaluator() {
+        givenImplIs(InterClusterRequestEvaluatorImpl.class.getName());
+        provider = new InterClusterRequestEvaluatorProvider(settings);
+        assertTrue("Exp. to use a custom evaluator when implementation is defined", provider.get() instanceof InterClusterRequestEvaluatorImpl);
+    }
+    
+    private void givenImplIs(String name) {
+        Builder builder = Settings.settingsBuilder();
+        if(name != null) {
+            builder.put(InterClusterRequestEvaluatorProvider.KEY, name);
+        }
+        settings = builder.build();
+    }
+
+    static class InterClusterRequestEvaluatorImpl implements InterClusterRequestEvaluator {
+
+        public InterClusterRequestEvaluatorImpl(Settings settings) {
+            
+        }
+        
+        @Override
+        public boolean isInterClusterRequest(TransportRequest request, X509Certificate[] certs) {
+            // TODO Auto-generated method stub
+            return false;
+        }
+        
+    }
+}


### PR DESCRIPTION
This PR:

* allows consumers to customize evaluation of cert attributes to determine intercluster communication
* makes the default implementation depend on SAN having the oid 
* alternate impl to compare the value of an OID on the server cert to the value of an OID from the client cert