### PR TITLE
Rebase #257 on branch breml-feature-user-restore

### DIFF
--- a/plugin-descriptor.properties
+++ b/plugin-descriptor.properties
@@ -3,7 +3,7 @@
 description=Provide access control related features for Elasticsearch 5
 #
 # 'version': plugin's version
-version=5.0.0-8
+version=5.0.0-9
 #
 # 'name': the plugin name
 name=search-guard-5

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <groupId>com.floragunn</groupId>
   <artifactId>search-guard-5</artifactId>
   <packaging>jar</packaging>
-  <version>5.0.0-9-SNAPSHOT</version>
+  <version>5.0.0-10-SNAPSHOT</version>
   <name>Search Guard</name>
   <description>Provide access control related features for Elasticsearch 5</description>
   <url>https://github.com/floragunncom/search-guard</url>

--- a/src/main/java/com/floragunn/searchguard/SearchGuardPlugin.java
+++ b/src/main/java/com/floragunn/searchguard/SearchGuardPlugin.java
@@ -320,7 +320,9 @@ public final class SearchGuardPlugin extends Plugin implements ActionPlugin {
 
         settings.add(Setting.boolSetting(ConfigConstants.SG_ENABLE_SNAPSHOT_RESTORE_PRIVILEGE, ConfigConstants.SG_DEFAULT_ENABLE_SNAPSHOT_RESTORE_PRIVILEGE,
                 Property.NodeScope, Property.Filtered));
-        
+        settings.add(Setting.boolSetting(ConfigConstants.SG_CHECK_SNAPSHOT_RESTORE_WRITE_PRIVILEGES, ConfigConstants.SG_DEFAULT_CHECK_SNAPSHOT_RESTORE_WRITE_PRIVILEGES,
+                Property.NodeScope, Property.Filtered));
+
         //SSL
         settings.add(Setting.simpleString(SSLConfigConstants.SEARCHGUARD_SSL_HTTP_CLIENTAUTH_MODE, Property.NodeScope, Property.Filtered));
         settings.add(Setting.simpleString(SSLConfigConstants.SEARCHGUARD_SSL_HTTP_KEYSTORE_ALIAS, Property.NodeScope, Property.Filtered));

--- a/src/main/java/com/floragunn/searchguard/support/ConfigConstants.java
+++ b/src/main/java/com/floragunn/searchguard/support/ConfigConstants.java
@@ -17,6 +17,11 @@
 
 package com.floragunn.searchguard.support;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 public class ConfigConstants {
     
      
@@ -67,7 +72,16 @@ public class ConfigConstants {
 
     public static final String SG_ENABLE_SNAPSHOT_RESTORE_PRIVILEGE = "searchguard.enable_snapshot_restore_privilege";
     public static final boolean SG_DEFAULT_ENABLE_SNAPSHOT_RESTORE_PRIVILEGE = false;
-    
+
+    public static final String SG_CHECK_SNAPSHOT_RESTORE_WRITE_PRIVILEGES = "searchguard.check_snapshot_restore_write_privileges";
+    public static final boolean SG_DEFAULT_CHECK_SNAPSHOT_RESTORE_WRITE_PRIVILEGES = true;
+    public static final Set<String> SG_SNAPSHOT_RESTORE_NEEDED_WRITE_PRIVILEGES = Collections.unmodifiableSet(
+            new HashSet<String>(Arrays.asList(
+                    "indices:admin/create",
+                    "indices:data/write/index"
+                    // "indices:data/write/bulk"
+              )));
+
     public final static String CONFIGNAME_ROLES = "roles";
     public final static String CONFIGNAME_ROLES_MAPPING = "rolesmapping";
     public final static String CONFIGNAME_ACTION_GROUPS = "actiongroups";

--- a/src/test/resources/sg_internal_users.yml
+++ b/src/test/resources/sg_internal_users.yml
@@ -77,7 +77,7 @@ dlsnoinvest:
 baz:
   hash: $2a$12$A41IxPXV1/Dx46C6i1ufGubv.p3qYX7xVcY46q33sylYbIqQVwTMu
   #password is: worf
-  
+
 user_role01:
   hash: '$2a$12$XrBfLQh2T8wIzpxE5vzhUOPjjGfONcD8UEjd5IT5KveG8ULZaj04.'
   # password is: user_role01
@@ -91,3 +91,7 @@ user_role01_role02_role03:
     - role01
     - role02
     - role03
+
+restoreuser:
+  hash: "$2a$12$JU2QjYVTlI24Q/enEOpf2uTLCPGchN.eXWCsrBiieUcRoeh53NB0y"
+  #password is: restoreuser

--- a/src/test/resources/sg_roles.yml
+++ b/src/test/resources/sg_roles.yml
@@ -281,7 +281,7 @@ sg_dlsnoinvest:
       '*':
         - ALL
       _dls_: '{"term" : {"category_code" : "software"}}'
-      
+
 sg_baz:
   cluster: 
     - ALL
@@ -292,9 +292,44 @@ sg_baz:
     'foo':
       'baz':
         - READ
-        
+
 sg_role01_role02:
   indices:
     'role01_role02':
       '*':
        - ALL
+
+sg_restore:
+  cluster:
+    - 'cluster:admin/snapshot/restore'
+  indices:
+    # everything set on one index definition
+    'vulcangov_restore_1':
+      '*':
+        - 'indices:admin/create'
+        - 'indices:data/write/index'
+    # combined rights lead to the allowance of the restore for 2a
+    'vulcangov_restore_2a':
+      '*':
+        - 'indices:admin/create'
+    'vulcangov_restore_2*':
+      '*':
+        - 'indices:data/write/index'
+    # type is not '*'
+    'vulcangov_no_restore_1':
+      'planet':
+        - 'indices:admin/create'
+        - 'indices:data/write/index'
+    # type is not '*'
+    'vulcangov_no_restore_2':
+      'p*':
+        - 'indices:admin/create'
+        - 'indices:data/write/index'
+    # permission indices:admin/create missing
+    'vulcangov_no_restore_3':
+      '*':
+        - 'indices:data/write/index'
+    # permission indices:data/write/index missing
+    'vulcangov_no_restore_4':
+      '*':
+        - 'indices:admin/create'

--- a/src/test/resources/sg_roles_mapping.yml
+++ b/src/test/resources/sg_roles_mapping.yml
@@ -101,12 +101,16 @@ sg_writer:
 sg_dlsnoinvest:
   users:
     - dlsnoinvest
-    
+
 sg_baz:
   users:
     - baz
-    
+
 sg_role01_role02:
   and_backendroles:
     - role01
     - role02
+
+sg_restore:
+  users:
+    - restoreuser


### PR DESCRIPTION
As suggested by @floragunncom in https://github.com/floragunncom/search-guard/pull/257#issuecomment-281176706 I rebased PR #257 on branch https://github.com/floragunncom/search-guard/tree/breml-feature-user-restore.

If this PR is merged with branch https://github.com/floragunncom/search-guard/tree/breml-feature-user-restore, this branch would then contain PR #245 and #257.

To keep the backwards compatibility of the now public PrivilegesEvaluator.IndexType I added a new PrivilegesEvaluator.IndexTypeAction, which extends PrivilegesEvaluator.IndexType.