### PR TITLE
Notify when 'sudo' is not installed

### DIFF
--- a/tools/install_demo_configuration.sh
+++ b/tools/install_demo_configuration.sh
@@ -36,9 +36,11 @@ if [ -f /usr/share/elasticsearch/bin/elasticsearch ]; then
     echo "This script maybe require your root password for 'sudo' privileges"
 fi
 
-if ! [ -x "$(command -v $SUDO_CMD)" ]; then
-   echo "Unable to locate 'sudo' command. Quit."
-   exit 1
+if [ $SUDO_CMD ]; then
+    if ! [ -x "$(command -v $SUDO_CMD)" ]; then
+        echo "Unable to locate 'sudo' command. Quit."
+        exit 1
+    fi
 fi
 
 if $SUDO_CMD test -f "$ES_CONF_FILE"; then

--- a/tools/install_demo_configuration.sh
+++ b/tools/install_demo_configuration.sh
@@ -36,6 +36,11 @@ if [ -f /usr/share/elasticsearch/bin/elasticsearch ]; then
     echo "This script maybe require your root password for 'sudo' privileges"
 fi
 
+if ! [ -x "$(command -v $SUDO_CMD)" ]; then
+   echo "Unable to locate 'sudo' command. Quit."
+   exit 1
+fi
+
 if $SUDO_CMD test -f "$ES_CONF_FILE"; then
     :
 else


### PR DESCRIPTION
Related: #385

The script is providing the wrong error feedback (saying it could not find the configuration directory) when run on Docker. The actual issue is that it cannot locate a suitable `sudo` command. While there is not specific advice for Docker users, this will at least clear up some confusion (potentially for other environments where `sudo` is purposefully removed) with the `install_demo_configuration.sh` script.