### PR TITLE
Add support for search-guard deployed as a Debian package, to

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,31 @@
                   <csvSummary>false</csvSummary>
             </configuration>
           </plugin>
+          <plugin>
+            <artifactId>jdeb</artifactId>
+            <groupId>org.vafer</groupId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>jdeb</goal>
+                </goals>
+                <configuration>
+                  <dataSet>
+                    <data>
+                      <src>${project.build.directory}/releases/${project.build.finalName}.zip</src>
+                      <type>file</type>
+                      <mapper>
+                        <type>perm</type>
+                        <prefix>/usr/share/${project.artifactId}</prefix>
+                      </mapper>
+                    </data>
+                  </dataSet>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
       <dependencies>

--- a/src/deb/control/control
+++ b/src/deb/control/control
@@ -1,0 +1,9 @@
+Package: [[artifactId]]
+Version: [[version]]
+Section: misc
+Priority: low
+Architecture: all
+Description: [[description]]
+Maintainer: floragunn GmbH <info@search-guard.com>
+Depends: libnetty-tcnative-java, default-jre-headless, elasticsearch (= [[elasticsearch.version]])
+Conflicts: search-guard-ssl

--- a/src/deb/control/postinst
+++ b/src/deb/control/postinst
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+PATH=${PATH}:/usr/bin
+
+if [ "configure" = "$1" ]; then
+  /usr/share/elasticsearch/bin/elasticsearch-plugin install -b file:///usr/share/[[artifactId]]/[[artifactId]]-[[project.version]].zip
+fi
+

--- a/src/deb/control/prerm
+++ b/src/deb/control/prerm
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+PATH=${PATH}:/usr/bin
+
+if [ "remove" = "$1" -o "upgrade" = "$1" ]; then
+  /usr/share/elasticsearch/bin/elasticsearch-plugin remove [[artifactId]]
+fi
+


### PR DESCRIPTION
correspond with the Debian package provided by Elasticsearch.

This package includes postinstall scripts to add the plugin, and preremove scripts to remove the plugin again on uninstall.
