### PR TITLE
Replace "MONITOR" action group by "INDICES_MONITOR"

### DIFF
--- a/sgconfig/sg_roles.yml
+++ b/sgconfig/sg_roles.yml
@@ -78,7 +78,7 @@ sg_readall_and_monitor:
 sg_kibana_user:
   readonly: true
   cluster:
-    - MONITOR
+    - INDICES_MONITOR
     - CLUSTER_COMPOSITE_OPS
   indices:
     '?kibana':


### PR DESCRIPTION
Action group "MONITOR" is deprecated and replaced by "INDICES_MONITOR".
See comment "# for backward compatibility" on "MONITOR" action group in sg_action_groups.yml.

P.S: I don't know why the online editor on Github has changed the last line of this file... Only the line "MONITOR" should be changed.

<!---
If you not have already signed our CLA (Contributor License Agreement) 
pls. send us an e-mail with your full name and your e-mail address to info(at)search-guard.com
or to the addresses listed here https://floragunn.com/contact .You will then receive the CLA via
DocuSign (https://www.docusign.com). Without a signed CLA we cannot merge your pull request!

You only need to sign the CLA once. It takes no longer that 2 minutes.
--->
