### PR TITLE
Filter log statements by user

### DIFF
--- a/src/main/java/com/floragunn/searchguard/auth/BackendRegistry.java
+++ b/src/main/java/com/floragunn/searchguard/auth/BackendRegistry.java
@@ -70,12 +70,12 @@ import com.google.common.cache.RemovalNotification;
 public class BackendRegistry implements ConfigurationChangeListener {
 
     protected final Logger log = LogManager.getLogger(this.getClass());
-    private final Map<String, String> authImplMap = new HashMap<String, String>();
-    private final SortedSet<AuthDomain> restAuthDomains = new TreeSet<AuthDomain>();
-    private final Set<AuthorizationBackend> restAuthorizers = new HashSet<AuthorizationBackend>();
-    private final SortedSet<AuthDomain> transportAuthDomains = new TreeSet<AuthDomain>();
-    private final Set<AuthorizationBackend> transportAuthorizers = new HashSet<AuthorizationBackend>();
-    private final List<Destroyable> destroyableComponents = new LinkedList<Destroyable>();
+    private final Map<String, String> authImplMap = new HashMap<>();
+    private final SortedSet<AuthDomain> restAuthDomains = new TreeSet<>();
+    private final Set<AuthorizationBackend> restAuthorizers = new HashSet<>();
+    private final SortedSet<AuthDomain> transportAuthDomains = new TreeSet<>();
+    private final Set<AuthorizationBackend> transportAuthorizers = new HashSet<>();
+    private final List<Destroyable> destroyableComponents = new LinkedList<>();
     private volatile boolean initialized;
     private final AdminDNs adminDns;
     private final XFFResolver xffResolver;

--- a/src/main/java/com/floragunn/searchguard/filter/SearchGuardFilter.java
+++ b/src/main/java/com/floragunn/searchguard/filter/SearchGuardFilter.java
@@ -256,7 +256,11 @@ public class SearchGuardFilter implements ActionFilter {
             }
 
             final PrivEvalResponse pres = eval.evaluate(user, action, request, task);
-
+            
+            if (log.isDebugEnabled()) {
+                log.debug(pres);
+            }
+            
             if (pres.isAllowed()) {
                 auditLog.logGrantedPrivileges(action, request, task);
                 if(!dlsFlsValve.invoke(request, listener, pres.getAllowedFlsFields(), pres.getQueries())) {

--- a/src/main/java/com/floragunn/searchguard/filter/SearchGuardRestFilter.java
+++ b/src/main/java/com/floragunn/searchguard/filter/SearchGuardRestFilter.java
@@ -44,6 +44,7 @@ import com.floragunn.searchguard.ssl.util.SSLRequestHelper;
 import com.floragunn.searchguard.ssl.util.SSLRequestHelper.SSLInfo;
 import com.floragunn.searchguard.support.ConfigConstants;
 import com.floragunn.searchguard.support.HTTPHelper;
+import com.floragunn.searchguard.user.User;
 
 public class SearchGuardRestFilter {
 
@@ -124,7 +125,11 @@ public class SearchGuardRestFilter {
                 && !"/_searchguard/health".equals(request.path())) {
             if (!registry.authenticate(request, channel, threadContext)) {
                 // another roundtrip
+                org.apache.logging.log4j.ThreadContext.remove("user");
                 return true;
+            } else {
+                // make it possible to filter logs by username
+                org.apache.logging.log4j.ThreadContext.put("user", ((User)threadContext.getTransient(ConfigConstants.SG_USER)).getName());
             }
         }
         

--- a/src/main/java/com/floragunn/searchguard/sgconf/ConfigModel.java
+++ b/src/main/java/com/floragunn/searchguard/sgconf/ConfigModel.java
@@ -28,6 +28,8 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -44,7 +46,8 @@ import com.google.common.collect.Sets;
 
 public class ConfigModel {
 
-    private final static Set<String> IGNORED_TYPES = ImmutableSet.of("_dls_", "_fls_","_masked_fields_");
+    protected final Logger log = LogManager.getLogger(this.getClass());
+    private static final Set<String> IGNORED_TYPES = ImmutableSet.of("_dls_", "_fls_","_masked_fields_");
     private final ActionGroupHolder ah;
     private final ConfigurationRepository configurationRepository;
 
@@ -133,6 +136,8 @@ public class ConfigModel {
 
     public static class SgRoles {
 
+        protected final Logger log = LogManager.getLogger(this.getClass());
+        
         final Set<SgRole> roles = new HashSet<>(100);
 
         private SgRoles() {
@@ -262,11 +267,6 @@ public class ConfigModel {
                             }
                         }
 
-
-                        //if (log.isDebugEnabled()) {
-                        //    log.debug("dls query {} for {}", dls, Arrays.toString(concreteIndices));
-                        //}
-
                     }
 
                     if(fls != null && fls.size() > 0) {
@@ -287,11 +287,6 @@ public class ConfigModel {
                                 flsFields.get(ci).addAll(Sets.newHashSet(fls));
                             }
                         }
-
-                        //if (log.isDebugEnabled()) {
-                        //    log.debug("fls fields {} for {}", Sets.newHashSet(fls), Arrays.toString(concreteIndices));
-                        //}
-
                     }
                 }
             }
@@ -313,6 +308,9 @@ public class ConfigModel {
             Set<String> retVal = new HashSet<>();
             for(SgRole sgr: roles) {
                 retVal.addAll(sgr.getAllResolvedPermittedIndices(resolved, user, actions, resolver, cs));
+            }
+            if(log.isDebugEnabled()) {
+                log.debug("Reduced requested resolved indices {} to permitted indices {}.", resolved, retVal.toString());
             }
             return Collections.unmodifiableSet(retVal);
         }

--- a/src/main/java/com/floragunn/searchguard/transport/SearchGuardRequestHandler.java
+++ b/src/main/java/com/floragunn/searchguard/transport/SearchGuardRequestHandler.java
@@ -210,10 +210,8 @@ public class SearchGuardRequestHandler<T extends TransportRequest> extends Searc
                     User user;
                     //try {
                         if((user = backendRegistry.authenticate(request, principal, task, task.getAction())) == null) {
-
-                            // make it possible to filter logs by username
-                            org.apache.logging.log4j.ThreadContext.put("user", user.getName());
-
+                            org.apache.logging.log4j.ThreadContext.remove("user");
+                           
                             if(task.getAction().equals(WhoAmIAction.NAME)) {
                                 super.messageReceivedDecorate(request, handler, transportChannel, task);
                                 return;
@@ -230,7 +228,8 @@ public class SearchGuardRequestHandler<T extends TransportRequest> extends Searc
                             transportChannel.sendResponse(new ElasticsearchSecurityException("Cannot authenticate "+getThreadContext().getTransient(ConfigConstants.SG_USER)));
                             return;
                         } else {
-                            org.apache.logging.log4j.ThreadContext.remove("user");
+                            // make it possible to filter logs by username
+                            org.apache.logging.log4j.ThreadContext.put("user", user.getName());
                         }
                     //} catch (Exception e) {
                         //    log.error("Error authentication transport user "+e, e);

--- a/src/main/java/com/floragunn/searchguard/transport/SearchGuardRequestHandler.java
+++ b/src/main/java/com/floragunn/searchguard/transport/SearchGuardRequestHandler.java
@@ -211,6 +211,9 @@ public class SearchGuardRequestHandler<T extends TransportRequest> extends Searc
                     //try {
                         if((user = backendRegistry.authenticate(request, principal, task, task.getAction())) == null) {
 
+                            // make it possible to filter logs by username
+                            org.apache.logging.log4j.ThreadContext.put("user", user.getName());
+
                             if(task.getAction().equals(WhoAmIAction.NAME)) {
                                 super.messageReceivedDecorate(request, handler, transportChannel, task);
                                 return;
@@ -226,6 +229,8 @@ public class SearchGuardRequestHandler<T extends TransportRequest> extends Searc
                             log.error("Cannot authenticate {} for {}", getThreadContext().getTransient(ConfigConstants.SG_USER), task.getAction());
                             transportChannel.sendResponse(new ElasticsearchSecurityException("Cannot authenticate "+getThreadContext().getTransient(ConfigConstants.SG_USER)));
                             return;
+                        } else {
+                            org.apache.logging.log4j.ThreadContext.remove("user");
                         }
                     //} catch (Exception e) {
                         //    log.error("Error authentication transport user "+e, e);


### PR DESCRIPTION
This PR adds the authenticated user to the log4j ThreadContext. This makes it possible to filter log messages by user and is most useful when debugging Kibana permission problems. You can filter the internal kibanaserver user in log4j2.properties like:

```
appender.console.type = Console
appender.console.name = console
appender.console.layout.type = PatternLayout
appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
appender.console.filter.user.type = ThreadContextMapFilter
appender.console.filter.user.onMatch=DENY
appender.console.filter.user.onMisMatch=NEUTRAL
appender.console.filter.user.value1.type=KeyValuePair
appender.console.filter.user.value1.key=user
appender.console.filter.user.value1.value=kibanaserver
```