### PR TITLE
Add cluster:monitor/xpack/info permission to read license

### DIFF
--- a/sgconfig/sg_roles.yml
+++ b/sgconfig/sg_roles.yml
@@ -158,6 +158,8 @@ sg_own_index:
 ### X-Pack COMPATIBILITY
 sg_xp_monitoring:
   readonly: true
+  cluster:
+    - cluster:monitor/xpack/info
   indices:
     '?monitor*':
       '*':

--- a/sgconfig/sg_roles.yml
+++ b/sgconfig/sg_roles.yml
@@ -160,6 +160,8 @@ sg_xp_monitoring:
   readonly: true
   cluster:
     - cluster:monitor/xpack/info
+    - cluster:monitor/main
+    - cluster:admin/xpack/monitoring/bulk
   indices:
     '?monitor*':
       '*':


### PR DESCRIPTION
Logstash needs `cluster:monitor/xpack/info permission` to read the license from the elasticsearch node, otherwise it won't start with monitoring enabled.

I'm not sure if there are needed for ML or Alerting (does Kibana read the license from ES too?).

Without permission:
```json
$ curl -u "user:pass" https://host:9200/_xpack?pretty
{
  "error" : {
    "root_cause" : [
      {
        "type" : "security_exception",
        "reason" : "no permissions for [cluster:monitor/xpack/info] and User [name= user, roles=[], requestedTenant=null]"
      }
    ],
    "type" : "security_exception",
    "reason" : "no permissions for [cluster:monitor/xpack/info] and User [name= user, roles=[], requestedTenant=null]"
  },
  "status" : 403
}
```

With permission:
```json
$ curl -u "user:pass" https://host:9200/_xpack?pretty
{
  "build" : {
    "hash" : "023779d",
    "date" : "2018-07-20T05:25:16.206115Z"
  },
  "license" : {
    "uid" : "uid_number",
    "type" : "basic",
    "mode" : "basic",
    "status" : "active"
  },
  "features" : {
    "graph" : {
      "description" : "Graph Data Exploration for the Elastic Stack",
      "available" : false,
      "enabled" : true
    },
    "logstash" : {
      "description" : "Logstash management component for X-Pack",
      "available" : false,
      "enabled" : true
    },
    "ml" : {
      "description" : "Machine Learning for the Elastic Stack",
      "available" : false,
      "enabled" : false,
      "native_code_info" : {
        "version" : "N/A",
        "build_hash" : "N/A"
      }
    },
    "monitoring" : {
      "description" : "Monitoring for the Elastic Stack",
      "available" : true,
      "enabled" : true
    },
    "rollup" : {
      "description" : "Time series pre-aggregation and rollup",
      "available" : true,
      "enabled" : true
    },
    "security" : {
      "description" : "Security for the Elastic Stack",
      "available" : false,
      "enabled" : false
    },
    "watcher" : {
      "description" : "Alerting, Notification and Automation for the Elastic Stack",
      "available" : false,
      "enabled" : false
    }
  },
  "tagline" : "You know, for X"
}
```