### PR TITLE
Refactor LicenseHelper::validateLicense to make it more readable

### DIFF
--- a/src/main/java/com/floragunn/searchguard/support/LicenseHelper.java
+++ b/src/main/java/com/floragunn/searchguard/support/LicenseHelper.java
@@ -79,12 +79,7 @@ public class LicenseHelper {
             //
             // https://github.com/bcgit/bc-java/blob/master/pg/src/test/java/org/bouncycastle/openpgp/test/PGPClearSignedSignatureTest.java
 
-            final ByteArrayOutputStream bout = new ByteArrayOutputStream();
-            int ch;
-
-            while ((ch = in.read()) >= 0 && in.isClearText()) {
-                bout.write((byte) ch);
-            }
+            final ByteArrayOutputStream bout = readClearText(in);
 
             final KeyFingerPrintCalculator c = new BcKeyFingerprintCalculator();
 
@@ -131,6 +126,16 @@ public class LicenseHelper {
         } catch (final Exception e) {
             throw new PGPException(e.toString(), e);
         }
+    }
+
+    private static ByteArrayOutputStream readClearText(ArmoredInputStream in) throws IOException {
+        final ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        int ch;
+
+        while ((ch = in.read()) >= 0 && in.isClearText()) {
+            bout.write((byte) ch);
+        }
+        return bout;
     }
 
     private static String removeNewLinesAndSCHNAPPHeaders(String licenseText) {

--- a/src/main/java/com/floragunn/searchguard/support/LicenseHelper.java
+++ b/src/main/java/com/floragunn/searchguard/support/LicenseHelper.java
@@ -67,10 +67,10 @@ public class LicenseHelper {
      */
     public static String validateLicense(String licenseText) throws PGPException {
 
-        licenseText = removeNewLinesAndSCHNAPPHeaders(licenseText);
+        final String cleanLicenseText = removeNewLinesAndSCHNAPPHeaders(licenseText);
 
         try {
-            final byte[] armoredPgp = BaseEncoding.base64().decode(licenseText);
+            final byte[] armoredPgp = BaseEncoding.base64().decode(cleanLicenseText);
 
             final ArmoredInputStream in = new ArmoredInputStream(new ByteArrayInputStream(armoredPgp));
 

--- a/src/main/java/com/floragunn/searchguard/support/LicenseHelper.java
+++ b/src/main/java/com/floragunn/searchguard/support/LicenseHelper.java
@@ -99,32 +99,36 @@ public class LicenseHelper {
                 throw new PGPException("license signature key mismatch");
             }
 
-            sig.init(new BcPGPContentVerifierBuilderProvider(), publicKey);
-
-            final ByteArrayOutputStream lineOut = new ByteArrayOutputStream();
-            final InputStream sigIn = new ByteArrayInputStream(bout.toByteArray());
-            int lookAhead = readInputLine(lineOut, sigIn);
-
-            processLine(sig, lineOut.toByteArray());
-
-            if (lookAhead != -1) {
-                do {
-                    lookAhead = readInputLine(lineOut, lookAhead, sigIn);
-
-                    sig.update((byte) '\r');
-                    sig.update((byte) '\n');
-
-                    processLine(sig, lineOut.toByteArray());
-                } while (lookAhead != -1);
-            }
-
-            if (!sig.verify()) {
-                throw new PGPException("Invalid license signature");
-            }
+            verifySignature(bout, sig, publicKey);
 
             return bout.toString();
         } catch (final Exception e) {
             throw new PGPException(e.toString(), e);
+        }
+    }
+
+    private static void verifySignature(ByteArrayOutputStream bout, PGPSignature sig, PGPPublicKey publicKey) throws PGPException, IOException, SignatureException {
+        sig.init(new BcPGPContentVerifierBuilderProvider(), publicKey);
+
+        final ByteArrayOutputStream lineOut = new ByteArrayOutputStream();
+        final InputStream sigIn = new ByteArrayInputStream(bout.toByteArray());
+        int lookAhead = readInputLine(lineOut, sigIn);
+
+        processLine(sig, lineOut.toByteArray());
+
+        if (lookAhead != -1) {
+            do {
+                lookAhead = readInputLine(lineOut, lookAhead, sigIn);
+
+                sig.update((byte) '\r');
+                sig.update((byte) '\n');
+
+                processLine(sig, lineOut.toByteArray());
+            } while (lookAhead != -1);
+        }
+
+        if (!sig.verify()) {
+            throw new PGPException("Invalid license signature");
         }
     }
 

--- a/src/main/java/com/floragunn/searchguard/support/LicenseHelper.java
+++ b/src/main/java/com/floragunn/searchguard/support/LicenseHelper.java
@@ -66,11 +66,9 @@ public class LicenseHelper {
      * @throws PGPException if validation fails
      */
     public static String validateLicense(String licenseText) throws PGPException {
-        
-    	licenseText = licenseText.trim().replaceAll("\\r|\\n", "");
-        licenseText = licenseText.replace("---- SCHNIPP (Armored PGP signed JSON as base64) ----","");
-        licenseText = licenseText.replace("---- SCHNAPP ----","");
-        
+
+        licenseText = removeNewLinesAndSCHNAPPHeaders(licenseText);
+
         try {
             final byte[] armoredPgp = BaseEncoding.base64().decode(licenseText);
 
@@ -133,6 +131,13 @@ public class LicenseHelper {
         } catch (final Exception e) {
             throw new PGPException(e.toString(), e);
         }
+    }
+
+    private static String removeNewLinesAndSCHNAPPHeaders(String licenseText) {
+        licenseText = licenseText.trim().replaceAll("\\r|\\n", "");
+        licenseText = licenseText.replace("---- SCHNIPP (Armored PGP signed JSON as base64) ----", "");
+        licenseText = licenseText.replace("---- SCHNAPP ----", "");
+        return licenseText;
     }
 
     private static int readInputLine(final ByteArrayOutputStream bOut, final InputStream fIn) throws IOException {

--- a/src/main/java/com/floragunn/searchguard/support/LicenseHelper.java
+++ b/src/main/java/com/floragunn/searchguard/support/LicenseHelper.java
@@ -74,10 +74,12 @@ public class LicenseHelper {
 
             final ArmoredInputStream in = new ArmoredInputStream(new ByteArrayInputStream(armoredPgp));
 
+            // Code copied from
+            // https://github.com/bcgit/bc-java/blob/master/pg/src/test/java/org/bouncycastle/openpgp/test/PGPClearSignedSignatureTest.java
+
             //
             // read the input, making sure we ignore the last newline.
             //
-            // https://github.com/bcgit/bc-java/blob/master/pg/src/test/java/org/bouncycastle/openpgp/test/PGPClearSignedSignatureTest.java
 
             final ByteArrayOutputStream plainLicenseJson = readClearText(in);
 

--- a/src/main/java/com/floragunn/searchguard/support/LicenseHelper.java
+++ b/src/main/java/com/floragunn/searchguard/support/LicenseHelper.java
@@ -88,14 +88,14 @@ public class LicenseHelper {
             final PGPPublicKeyRingCollection pgpRings = new PGPPublicKeyRingCollection(new ArmoredInputStream(
                     LicenseHelper.class.getResourceAsStream("/KEYS")), c);
 
-            if (sigL == null || pgpRings == null || sigL.size() == 0 || pgpRings.size() == 0) {
+            if (sigL == null || sigL.size() == 0 || pgpRings.size() == 0) {
                 throw new PGPException("Cannot find license signature");
             }
 
             final PGPSignature sig = sigL.get(0);
             final PGPPublicKey publicKey = pgpRings.getPublicKey(sig.getKeyID());
 
-            if (publicKey == null || sig == null) {
+            if (publicKey == null) {
                 throw new PGPException("license signature key mismatch");
             }
 

--- a/src/main/java/com/floragunn/searchguard/support/LicenseHelper.java
+++ b/src/main/java/com/floragunn/searchguard/support/LicenseHelper.java
@@ -116,15 +116,13 @@ public class LicenseHelper {
 
         processLine(sig, lineOut.toByteArray());
 
-        if (lookAhead != -1) {
-            do {
-                lookAhead = readInputLine(lineOut, lookAhead, sigIn);
+        while (lookAhead != -1) {
+            lookAhead = readInputLine(lineOut, lookAhead, sigIn);
 
-                sig.update((byte) '\r');
-                sig.update((byte) '\n');
+            sig.update((byte) '\r');
+            sig.update((byte) '\n');
 
-                processLine(sig, lineOut.toByteArray());
-            } while (lookAhead != -1);
+            processLine(sig, lineOut.toByteArray());
         }
 
         if (!sig.verify()) {


### PR DESCRIPTION
Hello,
**Problem:** The method LicenseHelper::validateLicense is long and not readable.
**Solution:** Refactor the method.
Extract a few helper methods, remove redundant null checks and simplify loop logic.

BTW, is the redundancy of  the null checks a bug ?
https://github.com/floragunncom/search-guard/commit/5080b138b176ea224d621201f7597ccbe0af2d19
Maybe the null checks should appear earlier - before using the variables that we check for null.


**Request for help**
I work on semi-automatic refactoring pull requests.
If you want to help me help you, and you think this project will benefit from refactoring PRs, please click the link below.
[![Yes - I want a refactoring service](https://refactormachine.com/wp-content/uploads/2018/09/yes-e1537456577294.jpeg)](https://refactormachine.com/refactoring-pull-requests-yes/)
If this PR annoys you, please click on the link below, so I will stop doing it in other repos as well
[![No please - it annoys me](https://refactormachine.com/wp-content/uploads/2018/09/no-e1537456561421.jpeg)](https://refactormachine.com/free-refactoring-pull-requests-service-no/)

**Extra note**:
Some of the code in this function was originally copied from 
https://github.com/bcgit/bc-java/blob/master/pg/src/test/java/org/bouncycastle/openpgp/test/PGPClearSignedSignatureTest.java
After refactoring, the correspondence will be weaker.

Best,
Assaf