### PR TITLE
Feature/integrators

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Logo](https://raw.githubusercontent.com/floragunncom/sg-assets/master/logo/sg_dlic_small.png) 
 
-Search Guard(®) is an Elasticsearch plugin that offers encryption, authentication, and authorization. It supports authentication via Active Directory, LDAP, Kerberos, JSON web tokens and many more, and includes fine grained role-based access control to clusters, indices, documents and fields. Enjoy true multi tenancy in Kibana, and stay compliant with GDPR, HIPAA, PCI, SOX and ISO by using audit logging. 
+Search Guard(®) is an Elasticsearch plugin that offers encryption, authentication, authorization. It supports authentication via Active Directory, LDAP, Kerberos, JSON web tokens, SAML, OpenID and many more. It includes fine grained role-based access control to indices, documents and fields. Enjoy true multi tenancy in Kibana, and stay compliant with GDPR, HIPAA, PCI, SOX and ISO by using audit and compliance logging. 
 
 Search Guard supports **OpenSSL** for maximum performance and security. The complete code is **Open Source**.
 
@@ -12,31 +12,38 @@ Search Guard offers all basic security features for free. The Community Edition 
 
 * Full data in transit encryption
 * Node-to-node encryption
-* Index level access control
-* Document type based access control
+* Certificate revocation lists
+* Role-based cluster level access control
+* Role-based index level access control
 * User-, role- and permission management
+* Internal user database
 * HTTP basic authentication
+* PKI authentication
+* Proxy authentication
 * User Impersonation
-* Proxy support
 
-Please see [here for a feature comparison](https://floragunn.com/searchguard-license-support/).
 
-## Enterprise Edition
+Please see [here for a feature comparison](https://search-guard.com/product#feature-comparison).
+
+## Enterprise and Compliance Edition
 
 The Enterprise Edition on Search Guard adds:
 
 * Active Directory / LDAP
 * Kerberos / SPNEGO
 * JSON web token (JWT)
+* OpenID
+* SAML
 * Document-level security
 * Field-level security
-* Audit logging to stay compliant with security compliance regulations
-* True Kibana Multi Tenancy
+* Audit logging 
+* Compliance logging for GDPR, HIPAA, PCI, SOX and ISO compliance
+* True Kibana multi-tenancy
 * REST management API
 
-Please see [here for a feature comparison](https://floragunn.com/searchguard-license-support/).
+Please see [here for a feature comparison](https://search-guard.com/product#feature-comparison).
 
-If you want to use our enterprise features in production, you need to obtain a license. We offer a [very flexible licensing model](https://floragunn.com/searchguard/searchguard-license-support/), based on productive clusters with an **unlimited number of nodes**. Non-productive systems like Development, Staging or QA are covered by the license at no additional cost.
+If you want to use our enterprise features in production, you need to obtain a license. We offer a [very flexible licensing model](https://search-guard.com/licensing/), based on productive clusters with an **unlimited number of nodes**. Non-productive systems like Development, Staging or QA are covered by the license at no additional cost.
 
 ## Trial license
 
@@ -50,11 +57,11 @@ Please refer to the [Official documentation](http://docs.search-guard.com) for d
 
 * Install Elasticsearch
 
-* Install the Search Guard plugin for your [Elasticsearch version](https://github.com/floragunncom/search-guard/wiki), e.g.:
+* Install the Search Guard plugin for your [Elasticsearch version](https://docs.search-guard.com/latest/search-guard-versions), e.g.:
 
 ```
 <ES directory>/bin/elasticsearch-plugin install \
-  -b com.floragunn:search-guard-6:6.0.0-17.beta1
+  -b com.floragunn:search-guard-6:6.4.0-23.0
 ```
 
 * ``cd`` into ``<ES directory>/plugins/search-guard-<version>/tools``
@@ -71,7 +78,7 @@ Please refer to the [Official documentation](http://docs.search-guard.com) for d
 
 ## Config hot reloading
 
-The Search Guard configuration is stored in a dedicated index in Elasticsearch itself. Changes to the configuration are pushed to this index via the [sgadmin command line tool](http://docs.search-guard.com/v6/sgadmin). This will trigger a reload of the configuration on all nodes automatically. This has several advantages over configuration via elasticsearch.yml:
+The Search Guard configuration is stored in a dedicated index in Elasticsearch itself. Changes to the configuration are pushed to this index via the [sgadmin command line tool](https://docs.search-guard.com/latest/sgadmin). This will trigger a reload of the configuration on all nodes automatically. This has several advantages over configuration via elasticsearch.yml:
 
 * Configuration is stored in a central place
 * No configuration files on the nodes necessary
@@ -79,9 +86,9 @@ The Search Guard configuration is stored in a dedicated index in Elasticsearch i
 * Configuration changes take effect immediately
 
 ## Support
-* Commercial support available through [floragunn GmbH](https://floragunn.com/searchguard/searchguard-license-support/)
+* Commercial support available through [floragunn GmbH](https://search-guard.com)
 * Community support available via [google groups](https://groups.google.com/forum/#!forum/search-guard)
-* Follow us and get community support on twitter [@searchguard](https://twitter.com/searchguard)
+* Follow us on twitter [@searchguard](https://twitter.com/searchguard)
 
 ## Legal 
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <artifactId>search-guard-6</artifactId>
   <packaging>jar</packaging>
   <!-- 6.x.y-a.b-->
-  <version>6.x-HEAD-SNAPSHOT</version>
+  <version>6.x-HEAD-SNAPSHOT-INTEGRATORS</version>
   <name>Search Guard</name>
   <description>Provide access control related features for Elasticsearch 6</description>
   <url>https://github.com/floragunncom/search-guard</url>

--- a/src/main/java/com/floragunn/searchguard/SearchGuardPlugin.java
+++ b/src/main/java/com/floragunn/searchguard/SearchGuardPlugin.java
@@ -913,7 +913,11 @@ public final class SearchGuardPlugin extends SearchGuardSSLPlugin implements Clu
         //compat
         settings.add(Setting.boolSetting(ConfigConstants.SEARCHGUARD_UNSUPPORTED_DISABLE_INTERTRANSPORT_AUTH_INITIALLY, false, Property.NodeScope, Property.Filtered));
         settings.add(Setting.boolSetting(ConfigConstants.SEARCHGUARD_UNSUPPORTED_DISABLE_REST_AUTH_INITIALLY, false, Property.NodeScope, Property.Filtered));
-        
+
+        //user injections
+        settings.add(Setting.boolSetting(ConfigConstants.SEARCHGUARD_UNSUPPORTED_INJECT_USER_ENABLED, false, Property.NodeScope, Property.Filtered));
+        settings.add(Setting.boolSetting(ConfigConstants.SEARCHGUARD_UNSUPPORTED_INJECT_ADMIN_USER_ENABLED, false, Property.NodeScope, Property.Filtered));
+
         return settings;
     }
 

--- a/src/main/java/com/floragunn/searchguard/action/whoami/TransportWhoAmIAction.java
+++ b/src/main/java/com/floragunn/searchguard/action/whoami/TransportWhoAmIAction.java
@@ -53,7 +53,7 @@ HandledTransportAction<WhoAmIRequest, WhoAmIResponse> {
     protected void doExecute(WhoAmIRequest request, ActionListener<WhoAmIResponse> listener) {
         final User user = threadPool.getThreadContext().getTransient(ConfigConstants.SG_USER);
         final String dn = user==null?threadPool.getThreadContext().getTransient(ConfigConstants.SG_SSL_TRANSPORT_PRINCIPAL):user.getName();
-        final boolean isAdmin = adminDNs.isAdmin(dn);
+        final boolean isAdmin = adminDNs.isAdminDN(dn);
         final boolean isAuthenticated = isAdmin?true: user != null;
         final boolean isNodeCertificateRequest = HeaderHelper.isInterClusterRequest(threadPool.getThreadContext()) || 
                 HeaderHelper.isTrustedClusterRequest(threadPool.getThreadContext());

--- a/src/main/java/com/floragunn/searchguard/auth/UserInjector.java
+++ b/src/main/java/com/floragunn/searchguard/auth/UserInjector.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2015-2018 floragunn GmbH
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+
+package com.floragunn.searchguard.auth;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import com.floragunn.searchguard.auditlog.AuditLog;
+import com.floragunn.searchguard.http.XFFResolver;
+import com.floragunn.searchguard.support.ConfigConstants;
+import com.floragunn.searchguard.support.SgUtils;
+import com.floragunn.searchguard.user.User;
+import com.google.common.base.Strings;
+
+public class UserInjector {
+
+    protected final Logger log = LogManager.getLogger(UserInjector.class);
+
+    private final ThreadPool threadPool;
+    private final AuditLog auditLog;
+    private final XFFResolver xffResolver;
+    private final Boolean injectUserEnabled;
+
+    UserInjector(Settings settings, ThreadPool threadPool, AuditLog auditLog, XFFResolver xffResolver) {
+        this.threadPool = threadPool;
+        this.auditLog = auditLog;
+        this.xffResolver = xffResolver;
+        this.injectUserEnabled = settings.getAsBoolean(ConfigConstants.SEARCHGUARD_UNSUPPORTED_INJECT_USER_ENABLED, false);
+
+    }
+
+    boolean injectUser(RestRequest request) {
+
+        if (!injectUserEnabled) {
+            return false;
+        }
+
+        String injectedUserString = threadPool.getThreadContext().getTransient(ConfigConstants.SG_INJECTED_USER);
+
+        if (log.isDebugEnabled()) {
+            log.debug("Injected user string: {}", injectedUserString);
+        }
+
+        if (Strings.isNullOrEmpty(injectedUserString)) {
+            return false;
+        }
+        // username|role1,role2|remoteIP:port|attributeKey,attributeValue,attributeKey,attributeValue, ...|requestedTenant
+        String[] parts = injectedUserString.split("\\|");
+
+        if (parts.length == 0) {
+            log.error("User string malformed, could not extract parts. User string was '{}.' User injection failed.", injectedUserString);
+            return false;
+        }
+
+        // username
+        if (Strings.isNullOrEmpty(parts[0])) {
+            log.error("Username must not be null, user string was '{}.' User injection failed.", injectedUserString);
+            return false;
+        }
+
+        final User user = new User(parts[0]);
+
+        // backend roles
+        if (parts.length > 1 && !Strings.isNullOrEmpty(parts[1])) {
+            if (parts[1].length() > 0) {
+                user.addRoles(Arrays.asList(parts[1].split(",")));
+            }
+        }
+
+        // custom attributes
+        if (parts.length > 3 && !Strings.isNullOrEmpty(parts[3])) {
+            Map<String, String> attributes = SgUtils.mapFromArray((parts[3].split(",")));
+            if (attributes == null) {
+                log.error("Could not parse custom attributes {}, user injection failed.", parts[3]);
+                return false;
+            } else {
+                user.addAttributes(attributes);
+            }
+        }
+
+        // requested tenant
+        if (parts.length > 4 && !Strings.isNullOrEmpty(parts[4])) {
+            user.setRequestedTenant(parts[4]);
+        }
+
+        // remote IP - we can set it only once, so we do it last. If non is given,
+        // BackendRegistry/XFFResolver will do the job
+        if (parts.length > 2 && !Strings.isNullOrEmpty(parts[2])) {
+            // format is ip:port
+            String[] ipAndPort = parts[2].split(":");
+            if (ipAndPort.length != 2) {
+                log.error("Remote address must have format ip:port, was: {}. User injection failed.", parts[2]);
+                return false;
+            } else {
+                try {
+                    InetAddress iAdress = InetAddress.getByName(ipAndPort[0]);
+                    int port = Integer.parseInt(ipAndPort[1]);
+                    threadPool.getThreadContext().putTransient(ConfigConstants.SG_REMOTE_ADDRESS, new TransportAddress(iAdress, port));
+                } catch (UnknownHostException | NumberFormatException e) {
+                    log.error("Cannot parse remote IP or port: {}, user injection failed.", parts[2], e);
+                    return false;
+                }
+            }
+        } else {
+            threadPool.getThreadContext().putTransient(ConfigConstants.SG_REMOTE_ADDRESS, xffResolver.resolve(request));
+        }
+
+        // mark user injected for proper admin handling
+        user.setInjected(true);
+
+        threadPool.getThreadContext().putTransient(ConfigConstants.SG_USER, user);
+        auditLog.logSucceededLogin(parts[0], true, null, request);
+        if (log.isTraceEnabled()) {
+            log.trace("Injected user object:{} ", user.toString());
+        }
+        return true;
+
+    }
+}

--- a/src/main/java/com/floragunn/searchguard/configuration/SearchGuardIndexSearcherWrapper.java
+++ b/src/main/java/com/floragunn/searchguard/configuration/SearchGuardIndexSearcherWrapper.java
@@ -78,7 +78,7 @@ public class SearchGuardIndexSearcherWrapper extends IndexSearcherWrapper {
 
         final User user = (User) threadContext.getTransient(ConfigConstants.SG_USER);
 
-        if (user != null && adminDns.isAdmin(user.getName())) {
+        if (user != null && adminDns.isAdmin(user)) {
             return true;
         }
 

--- a/src/main/java/com/floragunn/searchguard/filter/SearchGuardFilter.java
+++ b/src/main/java/com/floragunn/searchguard/filter/SearchGuardFilter.java
@@ -266,7 +266,7 @@ public class SearchGuardFilter implements ActionFilter {
     }
 
     private static boolean isUserAdmin(User user, final AdminDNs adminDns) {
-        if (user != null && adminDns.isAdmin(user.getName())) {
+        if (user != null && adminDns.isAdmin(user)) {
             return true;
         }
 

--- a/src/main/java/com/floragunn/searchguard/support/ConfigConstants.java
+++ b/src/main/java/com/floragunn/searchguard/support/ConfigConstants.java
@@ -73,6 +73,8 @@ public class ConfigConstants {
     public static final String SG_USER = SG_CONFIG_PREFIX+"user";
     public static final String SG_USER_HEADER = SG_CONFIG_PREFIX+"user_header";
 
+    public static final String SG_INJECTED_USER = "injected_user";
+    
     public static final String SG_XFF_DONE = SG_CONFIG_PREFIX+"xff_done";
 
     public static final String SSO_LOGOUT_URL = SG_CONFIG_PREFIX+"sso_logout_url";
@@ -214,5 +216,7 @@ public class ConfigConstants {
     public static final String SEARCHGUARD_UNSUPPORTED_RESTAPI_ACCEPT_INVALID_LICENSE = "searchguard.unsupported.restapi.accept_invalid_license";
     public static final String SEARCHGUARD_UNSUPPORTED_DISABLE_REST_AUTH_INITIALLY = "searchguard.unsupported.disable_rest_auth_initially";
     public static final String SEARCHGUARD_UNSUPPORTED_DISABLE_INTERTRANSPORT_AUTH_INITIALLY = "searchguard.unsupported.disable_intertransport_auth_initially";
+    public static final String SEARCHGUARD_UNSUPPORTED_INJECT_USER_ENABLED = "searchguard.unsupported.inject_user.enabled";
+    public static final String SEARCHGUARD_UNSUPPORTED_INJECT_ADMIN_USER_ENABLED = "searchguard.unsupported.inject_user.admin.enabled";
 
 }

--- a/src/main/java/com/floragunn/searchguard/support/SgUtils.java
+++ b/src/main/java/com/floragunn/searchguard/support/SgUtils.java
@@ -17,10 +17,18 @@
 
 package com.floragunn.searchguard.support;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 public final class SgUtils {
+    
+    protected final static Logger log = LogManager.getLogger(SgUtils.class);
     
     private SgUtils() {
     }
@@ -50,5 +58,21 @@ public final class SgUtils {
 
         return null;
     }
-
+    
+    @SafeVarargs
+    public static <T> Map<T, T>  mapFromArray(T ... keyValues) {
+        if(keyValues == null) {
+            return Collections.emptyMap();
+        }
+        if (keyValues.length % 2 != 0) {
+            log.error("Expected even number of key/value pairs, got {}.", Arrays.toString(keyValues));
+            return null;
+        }
+        Map<T, T> map = new HashMap<>();
+        
+        for(int i = 0; i<keyValues.length; i+=2) {
+            map.put(keyValues[i], keyValues[i+1]);
+        }
+        return map;
+    }
 }

--- a/src/main/java/com/floragunn/searchguard/user/User.java
+++ b/src/main/java/com/floragunn/searchguard/user/User.java
@@ -48,6 +48,7 @@ public class User implements Serializable, Writeable, CustomAttributesAware {
     private final Set<String> roles = new HashSet<String>();
     private String requestedTenant;
     private Map<String, String> attributes = new HashMap<>();
+    private boolean isInjected = false;
 
     public User(final StreamInput in) throws IOException {
         super();
@@ -135,6 +136,17 @@ public class User implements Serializable, Writeable, CustomAttributesAware {
     public final boolean isUserInRole(final String role) {
         return this.roles.contains(role);
     }
+
+    /**
+     * Associate this user with a set of roles
+     * 
+     * @param roles The roles
+     */
+    public final void addAttributes(final Map<String,String> attributes) {
+        if(attributes != null) {
+            this.attributes.putAll(attributes);
+        }
+    }
     
     public final String getRequestedTenant() {
         return requestedTenant;
@@ -142,6 +154,15 @@ public class User implements Serializable, Writeable, CustomAttributesAware {
 
     public final void setRequestedTenant(String requestedTenant) {
         this.requestedTenant = requestedTenant;
+    }
+    
+    
+    public boolean isInjected() {
+        return isInjected;
+    }
+
+    public void setInjected(boolean isInjected) {
+        this.isInjected = isInjected;
     }
 
     public final String toStringWithAttributes() {

--- a/src/test/java/com/floragunn/searchguard/LicenseTests.java
+++ b/src/test/java/com/floragunn/searchguard/LicenseTests.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.floragunn.searchguard.configuration.SearchGuardLicense;
@@ -94,6 +95,7 @@ public class LicenseTests extends SingleClusterTest {
     }
     
     @Test
+    @Ignore //ITT-1651
     public void testComplianceLicense() throws Exception {
 
         SearchGuardLicense license = SearchGuardLicense.createTrialLicense(new SimpleDateFormat("yyyy-MM-dd").format(new Date()), cs, "");

--- a/src/test/java/com/floragunn/searchguard/SystemIntegratorsTests.java
+++ b/src/test/java/com/floragunn/searchguard/SystemIntegratorsTests.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2015-2018 floragunn GmbH
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+
+package com.floragunn.searchguard;
+
+import org.apache.http.HttpStatus;
+import org.apache.http.message.BasicHeader;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.floragunn.searchguard.support.ConfigConstants;
+import com.floragunn.searchguard.test.SingleClusterTest;
+import com.floragunn.searchguard.test.helper.cluster.ClusterConfiguration;
+import com.floragunn.searchguard.test.helper.rest.RestHelper;
+import com.floragunn.searchguard.test.helper.rest.RestHelper.HttpResponse;
+import com.google.common.collect.Lists;
+
+public class SystemIntegratorsTests extends SingleClusterTest {
+    
+    @Test
+    public void testInjectedUserMalformed() throws Exception {
+    
+        final Settings settings = Settings.builder()                
+                .put(ConfigConstants.SEARCHGUARD_UNSUPPORTED_INJECT_USER_ENABLED, true)
+                .put("http.type", "com.floragunn.searchguard.http.UserInjectingServerTransport")
+                .build();
+                      
+        setup(settings, ClusterConfiguration.USERINJECTOR);
+        
+        final RestHelper rh = nonSslRestHelper();
+        // username|role1,role2|remoteIP|attributes
+        
+        HttpResponse resc;
+        
+        resc = rh.executeGetRequest("_searchguard/authinfo", new BasicHeader(ConfigConstants.SG_INJECTED_USER, null));
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, resc.getStatusCode());
+
+        resc = rh.executeGetRequest("_searchguard/authinfo", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "|||"));
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, resc.getStatusCode());
+        
+        resc = rh.executeGetRequest("_searchguard/authinfo", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "||127.0.0:80|"));
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, resc.getStatusCode());
+        
+        resc = rh.executeGetRequest("_searchguard/authinfo", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "username||ip|"));
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, resc.getStatusCode());
+
+        resc = rh.executeGetRequest("_searchguard/authinfo", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "username||ip:port|"));
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, resc.getStatusCode());
+
+        resc = rh.executeGetRequest("_searchguard/authinfo", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "username||ip:80|"));
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, resc.getStatusCode());
+
+        resc = rh.executeGetRequest("_searchguard/authinfo", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "username||127.0.x:80|"));
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, resc.getStatusCode());
+
+        resc = rh.executeGetRequest("_searchguard/authinfo", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "username||127.0.0:80|key1,value1,key2"));
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, resc.getStatusCode());
+
+        resc = rh.executeGetRequest("_searchguard/authinfo", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "||127.0.0:80|key1,value1,key2,value2"));
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, resc.getStatusCode());
+        
+    }
+
+    @Test
+    public void testInjectedUser() throws Exception {
+    
+        final Settings settings = Settings.builder()                
+                .put(ConfigConstants.SEARCHGUARD_UNSUPPORTED_INJECT_USER_ENABLED, true)
+                .put("http.type", "com.floragunn.searchguard.http.UserInjectingServerTransport")
+                .build();
+                      
+        setup(settings, ClusterConfiguration.USERINJECTOR);
+        
+        final RestHelper rh = nonSslRestHelper();
+        // username|role1,role2|remoteIP|attributes
+        
+        HttpResponse resc;
+               
+        resc = rh.executeGetRequest("_searchguard/authinfo", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "admin||127.0.0:80|"));
+        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        Assert.assertTrue(resc.getBody().contains("User [name=admin, roles=[], requestedTenant=null]"));
+        Assert.assertTrue(resc.getBody().contains("\"remote_address\":\"127.0.0.0:80\""));
+        Assert.assertTrue(resc.getBody().contains("\"backend_roles\":[]"));
+        Assert.assertTrue(resc.getBody().contains("\"custom_attribute_names\":[]"));
+
+        resc = rh.executeGetRequest("_searchguard/authinfo", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "admin|role1|127.0.0:80|key1,value1"));
+        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        Assert.assertTrue(resc.getBody().contains("User [name=admin, roles=[role1], requestedTenant=null]"));
+        Assert.assertTrue(resc.getBody().contains("\"remote_address\":\"127.0.0.0:80\""));
+        Assert.assertTrue(resc.getBody().contains("\"backend_roles\":[\"role1\"]"));
+        Assert.assertTrue(resc.getBody().contains("\"custom_attribute_names\":[\"key1\"]"));
+
+        resc = rh.executeGetRequest("_searchguard/authinfo", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "admin|role1,role2||key1,value1"));
+        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        Assert.assertTrue(resc.getBody().contains("User [name=admin, roles=[role1, role2], requestedTenant=null]"));
+        // remote IP is assigned by XFFResolver
+        Assert.assertFalse(resc.getBody().contains("\"remote_address\":null"));
+        Assert.assertTrue(resc.getBody().contains("\"backend_roles\":[\"role1\",\"role2\"]"));
+        Assert.assertTrue(resc.getBody().contains("\"custom_attribute_names\":[\"key1\"]"));
+
+        resc = rh.executeGetRequest("_searchguard/authinfo", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "admin|role1,role2|8.8.8.8:8|key1,value1,key2,value2"));
+        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        Assert.assertTrue(resc.getBody().contains("User [name=admin, roles=[role1, role2], requestedTenant=null]"));
+        // remote IP is assigned by XFFResolver
+        Assert.assertFalse(resc.getBody().contains("\"remote_address\":null"));
+        Assert.assertTrue(resc.getBody().contains("\"backend_roles\":[\"role1\",\"role2\"]"));
+        Assert.assertTrue(resc.getBody().contains("\"custom_attribute_names\":[\"key1\",\"key2\"]"));
+
+        resc = rh.executeGetRequest("_searchguard/authinfo", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "nagilum|role1,role2|8.8.8.8:8|key1,value1,key2,value2"));
+        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        Assert.assertTrue(resc.getBody().contains("User [name=nagilum, roles=[role1, role2], requestedTenant=null]"));
+        // remote IP is assigned by XFFResolver
+        Assert.assertTrue(resc.getBody().contains("\"remote_address\":\"8.8.8.8:8\""));
+        Assert.assertTrue(resc.getBody().contains("\"backend_roles\":[\"role1\",\"role2\"]"));
+        // mapped by username
+        Assert.assertTrue(resc.getBody().contains("\"sg_roles\":[\"sg_all_access\""));
+        Assert.assertTrue(resc.getBody().contains("\"custom_attribute_names\":[\"key1\",\"key2\"]"));
+        
+        resc = rh.executeGetRequest("_searchguard/authinfo", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "myuser|role1,vulcanadmin|8.8.8.8:8|key1,value1,key2,value2"));
+        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        Assert.assertTrue(resc.getBody().contains("User [name=myuser, roles=[role1, vulcanadmin], requestedTenant=null]"));
+        // remote IP is assigned by XFFResolver
+        Assert.assertTrue(resc.getBody().contains("\"remote_address\":\"8.8.8.8:8\""));
+        Assert.assertTrue(resc.getBody().contains("\"backend_roles\":[\"role1\",\"vulcanadmin\"]"));
+        // mapped by backend role "twitter"
+        Assert.assertTrue(resc.getBody().contains("\"sg_roles\":[\"sg_public\",\"sg_role_vulcans_admin\"]"));
+        Assert.assertTrue(resc.getBody().contains("\"custom_attribute_names\":[\"key1\",\"key2\"]"));
+        
+        // add requested tenant
+        resc = rh.executeGetRequest("_searchguard/authinfo", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "myuser|role1,vulcanadmin|8.8.8.8:8|key1,value1,key2,value2|"));
+        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        Assert.assertTrue(resc.getBody().contains("User [name=myuser, roles=[role1, vulcanadmin], requestedTenant=null]"));
+        // remote IP is assigned by XFFResolver
+        Assert.assertTrue(resc.getBody().contains("\"remote_address\":\"8.8.8.8:8\""));
+        Assert.assertTrue(resc.getBody().contains("\"backend_roles\":[\"role1\",\"vulcanadmin\"]"));
+        // mapped by backend role "twitter"
+        Assert.assertTrue(resc.getBody().contains("\"sg_roles\":[\"sg_public\",\"sg_role_vulcans_admin\"]"));
+        Assert.assertTrue(resc.getBody().contains("\"custom_attribute_names\":[\"key1\",\"key2\"]"));
+
+        resc = rh.executeGetRequest("_searchguard/authinfo", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "myuser|role1,vulcanadmin|8.8.8.8:8|key1,value1,key2,value2|mytenant"));
+        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        Assert.assertTrue(resc.getBody().contains("User [name=myuser, roles=[role1, vulcanadmin], requestedTenant=mytenant]"));
+        // remote IP is assigned by XFFResolver
+        Assert.assertTrue(resc.getBody().contains("\"remote_address\":\"8.8.8.8:8\""));
+        Assert.assertTrue(resc.getBody().contains("\"backend_roles\":[\"role1\",\"vulcanadmin\"]"));
+        // mapped by backend role "twitter"
+        Assert.assertTrue(resc.getBody().contains("\"sg_roles\":[\"sg_public\",\"sg_role_vulcans_admin\"]"));
+        Assert.assertTrue(resc.getBody().contains("\"custom_attribute_names\":[\"key1\",\"key2\"]"));
+
+        resc = rh.executeGetRequest("_searchguard/authinfo", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "myuser|role1,vulcanadmin|8.8.8.8:8||mytenant with whitespace"));
+        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        Assert.assertTrue(resc.getBody().contains("User [name=myuser, roles=[role1, vulcanadmin], requestedTenant=mytenant with whitespace]"));
+        // remote IP is assigned by XFFResolver
+        Assert.assertTrue(resc.getBody().contains("\"remote_address\":\"8.8.8.8:8\""));
+        Assert.assertTrue(resc.getBody().contains("\"backend_roles\":[\"role1\",\"vulcanadmin\"]"));
+        // mapped by backend role "twitter"
+        Assert.assertTrue(resc.getBody().contains("\"sg_roles\":[\"sg_public\",\"sg_role_vulcans_admin\"]"));
+        
+
+    }    
+
+    @Test
+    public void testInjectedUserDisabled() throws Exception {
+    
+        final Settings settings = Settings.builder()                
+                .put("http.type", "com.floragunn.searchguard.http.UserInjectingServerTransport")
+                .build();
+                      
+        setup(settings, ClusterConfiguration.USERINJECTOR);
+        
+        final RestHelper rh = nonSslRestHelper();
+        // username|role1,role2|remoteIP|attributes
+        
+        HttpResponse resc;
+               
+        resc = rh.executeGetRequest("_searchguard/authinfo", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "admin|role1|127.0.0:80|key1,value1"));
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, resc.getStatusCode());
+    }
+
+  @Test
+  public void testInjectedAdminUser() throws Exception {
+  
+      final Settings settings = Settings.builder()                
+              .put(ConfigConstants.SEARCHGUARD_UNSUPPORTED_INJECT_USER_ENABLED, true)
+              .put(ConfigConstants.SEARCHGUARD_UNSUPPORTED_INJECT_ADMIN_USER_ENABLED, true)
+              .putList(ConfigConstants.SEARCHGUARD_AUTHCZ_ADMIN_DN, Lists.newArrayList("CN=kirk,OU=client,O=client,L=Test,C=DE","injectedadmin"))
+              .put("http.type", "com.floragunn.searchguard.http.UserInjectingServerTransport")
+              .build();
+                    
+      setup(settings, ClusterConfiguration.USERINJECTOR);
+      
+      final RestHelper rh = nonSslRestHelper();
+      HttpResponse resc;
+      
+      // injected user is admin, access to SG index must be allowed
+      resc = rh.executeGetRequest("searchguard/_search?pretty", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "injectedadmin|role1|127.0.0:80|key1,value1"));
+      Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+      Assert.assertTrue(resc.getBody().contains("\"_id\" : \"config\""));
+      Assert.assertTrue(resc.getBody().contains("\"_id\" : \"roles\""));
+      Assert.assertTrue(resc.getBody().contains("\"_id\" : \"internalusers\""));
+      Assert.assertTrue(resc.getBody().contains("\"_id\" : \"tattr\""));
+      Assert.assertTrue(resc.getBody().contains("\"total\" : 6"));
+      
+      resc = rh.executeGetRequest("searchguard/_search?pretty", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "wrongadmin|role1|127.0.0:80|key1,value1"));
+      Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+      
+  }
+
+    @Test
+    public void testInjectedAdminUserAdminInjectionDisabled() throws Exception {
+    
+        final Settings settings = Settings.builder()                
+                .put(ConfigConstants.SEARCHGUARD_UNSUPPORTED_INJECT_USER_ENABLED, true)
+                .putList(ConfigConstants.SEARCHGUARD_AUTHCZ_ADMIN_DN, Lists.newArrayList("CN=kirk,OU=client,O=client,L=Test,C=DE","injectedadmin"))
+                .put("http.type", "com.floragunn.searchguard.http.UserInjectingServerTransport")
+                .build();
+                      
+        setup(settings, ClusterConfiguration.USERINJECTOR);
+        
+        final RestHelper rh = nonSslRestHelper();
+        HttpResponse resc;
+        
+        // injected user is admin, access to SG index must be allowed
+        resc = rh.executeGetRequest("searchguard/_search?pretty", new BasicHeader(ConfigConstants.SG_INJECTED_USER, "injectedadmin|role1|127.0.0:80|key1,value1"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        Assert.assertFalse(resc.getBody().contains("\"_id\" : \"config\""));
+        Assert.assertFalse(resc.getBody().contains("\"_id\" : \"roles\""));
+        Assert.assertFalse(resc.getBody().contains("\"_id\" : \"internalusers\""));
+        Assert.assertFalse(resc.getBody().contains("\"_id\" : \"tattr\""));
+        Assert.assertFalse(resc.getBody().contains("\"total\" : 6"));
+                
+    }    
+
+}

--- a/src/test/java/com/floragunn/searchguard/UtilTests.java
+++ b/src/test/java/com/floragunn/searchguard/UtilTests.java
@@ -17,15 +17,23 @@
 
 package com.floragunn.searchguard;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.floragunn.searchguard.support.SgUtils;
 import com.floragunn.searchguard.support.WildcardMatcher;
 
-public class WildcardTests {
+public class UtilTests {
     
     @Test
-    public void test() {
+    public void testWildcards() {
         Assert.assertTrue(!WildcardMatcher.match("a*?", "a"));
         Assert.assertTrue(WildcardMatcher.match("a*?", "aa"));
         Assert.assertTrue(WildcardMatcher.match("a*?", "ab"));
@@ -49,5 +57,34 @@ public class WildcardTests {
         Assert.assertTrue(WildcardMatcher.containsWildcard("abc*"));
         Assert.assertTrue(WildcardMatcher.containsWildcard("a?bc"));
         Assert.assertTrue(WildcardMatcher.containsWildcard("/(\\d{3}-\\d{2}-?\\d{4})/"));
+    }
+
+    @Test
+    public void testMapFromArray() {
+        Map<Object, Object> map = SgUtils.mapFromArray((Object)null);
+        assertTrue(map == null);
+        
+        map = SgUtils.mapFromArray("key");
+        assertTrue(map == null);
+
+        map = SgUtils.mapFromArray("key", "value", "otherkey");
+        assertTrue(map == null);
+        
+        map = SgUtils.mapFromArray("key", "value");
+        assertNotNull(map);        
+        assertEquals(1, map.size());
+        assertEquals("value", map.get("key"));
+
+        map = SgUtils.mapFromArray("key", "value", "key", "value");
+        assertNotNull(map);        
+        assertEquals(1, map.size());
+        assertEquals("value", map.get("key"));
+
+        map = SgUtils.mapFromArray("key1", "value1", "key2", "value2");
+        assertNotNull(map);        
+        assertEquals(2, map.size());
+        assertEquals("value1", map.get("key1"));
+        assertEquals("value2", map.get("key2"));
+
     }
 }

--- a/src/test/java/com/floragunn/searchguard/test/helper/cluster/ClusterConfiguration.java
+++ b/src/test/java/com/floragunn/searchguard/test/helper/cluster/ClusterConfiguration.java
@@ -22,6 +22,18 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.elasticsearch.index.reindex.ReindexPlugin;
+import org.elasticsearch.join.ParentJoinPlugin;
+import org.elasticsearch.percolator.PercolatorPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.script.mustache.MustachePlugin;
+import org.elasticsearch.search.aggregations.matrix.MatrixAggregationPlugin;
+import org.elasticsearch.transport.Netty4Plugin;
+
+import com.floragunn.searchguard.SearchGuardPlugin;
+import com.floragunn.searchguard.test.plugin.UserInjectorPlugin;
+import com.google.common.collect.Lists;
+
 public enum ClusterConfiguration {
 	//first one needs to be a master
     //HUGE(new NodeSettings(true, false, false), new NodeSettings(true, false, false), new NodeSettings(true, false, false), new NodeSettings(false, true,false), new NodeSettings(false, true, false)),
@@ -33,8 +45,11 @@ public enum ClusterConfiguration {
 	SINGLENODE(new NodeSettings(true, true, false)),
     
 	//4 node (1m, 2d, 1c)
-	CLIENTNODE(new NodeSettings(true, false, false), new NodeSettings(false, true, false), new NodeSettings(false, true, false), new NodeSettings(false, false, false));
-	
+	CLIENTNODE(new NodeSettings(true, false, false), new NodeSettings(false, true, false), new NodeSettings(false, true, false), new NodeSettings(false, false, false)),
+
+    //3 nodes (1m, 2d) plus additional UserInjectorPlugin
+    USERINJECTOR(new NodeSettings(true, false, false, Lists.newArrayList(UserInjectorPlugin.class)), new NodeSettings(false, true, false, Lists.newArrayList(UserInjectorPlugin.class)), new NodeSettings(false, true, false, Lists.newArrayList(UserInjectorPlugin.class)));
+
 	private List<NodeSettings> nodeSettings = new LinkedList<>();
 	
 	private ClusterConfiguration(NodeSettings ... settings) {
@@ -65,6 +80,7 @@ public enum ClusterConfiguration {
 		public boolean masterNode;
 		public boolean dataNode;
 		public boolean tribeNode;
+		public List<Class<? extends Plugin>> plugins = Lists.newArrayList(Netty4Plugin.class, SearchGuardPlugin.class, MatrixAggregationPlugin.class, MustachePlugin.class, ParentJoinPlugin.class, PercolatorPlugin.class, ReindexPlugin.class);
 		
 		public NodeSettings(boolean masterNode, boolean dataNode, boolean tribeNode) {
 			super();
@@ -72,6 +88,14 @@ public enum ClusterConfiguration {
 			this.dataNode = dataNode;
 			this.tribeNode = tribeNode;
 		}
+        
+		public NodeSettings(boolean masterNode, boolean dataNode, boolean tribeNode, List<Class<? extends Plugin>> additionalPlugins) {
+            this(masterNode, dataNode, tribeNode);
+            this.plugins.addAll(additionalPlugins);
+        }
 		
+		public Class<? extends Plugin>[] getPlugins() {
+		    return plugins.toArray(new Class[0] );
+		}
 	}
 }

--- a/src/test/java/com/floragunn/searchguard/test/helper/cluster/ClusterHelper.java
+++ b/src/test/java/com/floragunn/searchguard/test/helper/cluster/ClusterHelper.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -45,16 +44,9 @@ import org.elasticsearch.cluster.node.DiscoveryNode.Role;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.index.reindex.ReindexPlugin;
-import org.elasticsearch.join.ParentJoinPlugin;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.PluginAwareNode;
-import org.elasticsearch.percolator.PercolatorPlugin;
-import org.elasticsearch.script.mustache.MustachePlugin;
-import org.elasticsearch.search.aggregations.matrix.MatrixAggregationPlugin;
-import org.elasticsearch.transport.Netty4Plugin;
 
-import com.floragunn.searchguard.SearchGuardPlugin;
 import com.floragunn.searchguard.test.NodeSettingsSupplier;
 import com.floragunn.searchguard.test.helper.cluster.ClusterConfiguration.NodeSettings;
 import com.floragunn.searchguard.test.helper.network.SocketUtils;
@@ -129,10 +121,10 @@ public final class ClusterHelper {
 		for (int i = 0; i < internalNodeSettings.size(); i++) {
 			NodeSettings setting = internalNodeSettings.get(i);
 			
+			
 			PluginAwareNode node = new PluginAwareNode(setting.masterNode,
 					getMinimumNonSgNodeSettingsBuilder(i, setting.masterNode, setting.dataNode, setting.tribeNode, internalNodeSettings.size(), clusterConfiguration.getMasterNodes(), tcpPorts, tcpPortsIt.next(), httpPortsIt.next())
-							.put(nodeSettingsSupplier == null ? Settings.Builder.EMPTY_SETTINGS : nodeSettingsSupplier.get(i)).build(),
-					Netty4Plugin.class, SearchGuardPlugin.class, MatrixAggregationPlugin.class, MustachePlugin.class, ParentJoinPlugin.class, PercolatorPlugin.class, ReindexPlugin.class);
+							.put(nodeSettingsSupplier == null ? Settings.Builder.EMPTY_SETTINGS : nodeSettingsSupplier.get(i)).build(), setting.getPlugins());
 			System.out.println(node.settings());
 			
 			new Thread(new Runnable() {

--- a/src/test/java/com/floragunn/searchguard/test/plugin/UserInjectorPlugin.java
+++ b/src/test/java/com/floragunn/searchguard/test/plugin/UserInjectorPlugin.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2015-2018 floragunn GmbH
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+
+package com.floragunn.searchguard.test.plugin;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.network.NetworkService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.http.HttpServerTransport.Dispatcher;
+import org.elasticsearch.http.netty4.Netty4HttpServerTransport;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.plugins.NetworkPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import com.floragunn.searchguard.support.ConfigConstants;
+
+/**
+ * Mimics the behavior of system integrators that run their own plugins (i.e. server transports)
+ * in front of Search Guard. This transport just copies the user string from the
+ * REST headers to the ThreadContext to test user injection.
+ * @author jkressin
+ */
+public class UserInjectorPlugin extends Plugin implements NetworkPlugin {
+    
+    Settings settings;
+    ThreadPool threadPool;
+    
+    public UserInjectorPlugin(final Settings settings, final Path configPath) {        
+        this.settings = settings;
+    }
+
+    @Override
+    public Map<String, Supplier<HttpServerTransport>> getHttpTransports(Settings settings, ThreadPool threadPool, BigArrays bigArrays,
+            CircuitBreakerService circuitBreakerService, NamedWriteableRegistry namedWriteableRegistry,
+            NamedXContentRegistry xContentRegistry, NetworkService networkService, Dispatcher dispatcher) {
+
+        Map<String, Supplier<HttpServerTransport>> httpTransports = new HashMap<String, Supplier<HttpServerTransport>>(1);
+        final UserInjectingDispatcher validatingDispatcher = new UserInjectingDispatcher(dispatcher);
+        httpTransports.put("com.floragunn.searchguard.http.UserInjectingServerTransport", () -> new UserInjectingServerTransport(settings, networkService, bigArrays, threadPool, xContentRegistry, validatingDispatcher));        
+        return httpTransports;
+    }
+    
+    class UserInjectingServerTransport extends Netty4HttpServerTransport {
+        
+        public UserInjectingServerTransport(final Settings settings, final NetworkService networkService, final BigArrays bigArrays,
+                final ThreadPool threadPool, final NamedXContentRegistry namedXContentRegistry, final Dispatcher dispatcher) {
+            super(settings, networkService, bigArrays, threadPool, namedXContentRegistry, dispatcher);                        
+        }
+    }
+    
+    class UserInjectingDispatcher implements Dispatcher {
+        
+        private Dispatcher originalDispatcher;
+
+        public UserInjectingDispatcher(final Dispatcher originalDispatcher) {
+            super();
+            this.originalDispatcher = originalDispatcher;
+        }
+
+        @Override
+        public void dispatchRequest(RestRequest request, RestChannel channel, ThreadContext threadContext) {
+            threadContext.putTransient(ConfigConstants.SG_INJECTED_USER, request.header(ConfigConstants.SG_INJECTED_USER));
+            originalDispatcher.dispatchRequest(request, channel, threadContext);
+            
+        }
+
+        @Override
+        public void dispatchBadRequest(RestRequest request, RestChannel channel, ThreadContext threadContext,
+                Throwable cause) {
+            threadContext.putTransient(ConfigConstants.SG_INJECTED_USER, request.header(ConfigConstants.SG_INJECTED_USER));
+            originalDispatcher.dispatchBadRequest(request, channel, threadContext, cause);
+            
+        }
+    }
+    
+}


### PR DESCRIPTION
This PR provides inofficial features that help OEM partners to integrate Search Guard in their environments, especially cloud-based environments. This PR enables integrators to inject a Search Guard user via the ThreadContext and to elevate this user to an admin user. Using this feature mandates that end users do not have access to the transport port, e.g. usage of a transport client is disallowed. 
