### PR TITLE
Redirect stderr of sgadmin to /dev/null

### DIFF
--- a/src/main/java/com/floragunn/searchguard/tools/SearchGuardAdmin.java
+++ b/src/main/java/com/floragunn/searchguard/tools/SearchGuardAdmin.java
@@ -337,7 +337,7 @@ public class SearchGuardAdmin {
             
         }
         catch( ParseException exp ) {
-            System.err.println("ERR: Parsing failed.  Reason: " + exp.getMessage());
+            System.out.println("ERR: Parsing failed.  Reason: " + exp.getMessage());
             formatter.printHelp("sgadmin.sh", options, true);
             return;
         }

--- a/tools/sgadmin.bat
+++ b/tools/sgadmin.bat
@@ -1,3 +1,3 @@
 @echo off
 set SCRIPT_DIR=%~dp0
-"%JAVA_HOME%\bin\java" -Dorg.apache.logging.log4j.simplelog.StatusLogger.level=OFF -cp "%SCRIPT_DIR%\..\..\search-guard-ssl\*;%SCRIPT_DIR%\..\deps\*;%SCRIPT_DIR%\..\*;%SCRIPT_DIR%\..\..\..\lib\*" com.floragunn.searchguard.tools.SearchGuardAdmin %*
+"%JAVA_HOME%\bin\java" -Dorg.apache.logging.log4j.simplelog.StatusLogger.level=OFF -cp "%SCRIPT_DIR%\..\..\search-guard-ssl\*;%SCRIPT_DIR%\..\deps\*;%SCRIPT_DIR%\..\*;%SCRIPT_DIR%\..\..\..\lib\*" com.floragunn.searchguard.tools.SearchGuardAdmin %* 2> nul

--- a/tools/sgadmin.sh
+++ b/tools/sgadmin.sh
@@ -8,5 +8,5 @@ else
     BIN_PATH="$JAVA_HOME/bin/java"
 fi
 
-"$BIN_PATH" $JAVA_OPTS -Dorg.apache.logging.log4j.simplelog.StatusLogger.level=OFF -cp "$DIR/../*:$DIR/../../../lib/*:$DIR/../deps/*" com.floragunn.searchguard.tools.SearchGuardAdmin "$@"
+"$BIN_PATH" $JAVA_OPTS -Dorg.apache.logging.log4j.simplelog.StatusLogger.level=OFF -cp "$DIR/../*:$DIR/../../../lib/*:$DIR/../deps/*" com.floragunn.searchguard.tools.SearchGuardAdmin "$@" 2>/dev/null
 


### PR DESCRIPTION
This will suppress "WARNING: An illegal reflective access operation has occurred" when running with Java >= 9

We need to test this in the integ tests (and also the .bat on Windows)