### PR TITLE
Fix "user id is too big" when running maven assembly plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,7 @@
                 <phase>package</phase>
                 <configuration>
                   <appendAssemblyId>false</appendAssemblyId>
+                  <tarLongFileMode>posix</tarLongFileMode>
                   <outputDirectory>${project.build.directory}/releases/</outputDirectory>
                   <descriptors>
                     <descriptor>${elasticsearch.assembly.descriptor}</descriptor>
@@ -266,6 +267,7 @@
                 <phase>package</phase>
                 <configuration>
                   <appendAssemblyId>true</appendAssemblyId>
+                  <tarLongFileMode>posix</tarLongFileMode>
                   <outputDirectory>${project.build.directory}/releases/</outputDirectory>
                   <descriptors>
                     <descriptor>${sgstandalone.descriptor}</descriptor>
@@ -368,6 +370,7 @@
                 <phase>package</phase>
                 <configuration>
                   <appendAssemblyId>true</appendAssemblyId>
+                  <tarLongFileMode>posix</tarLongFileMode>
                   <outputDirectory>${project.build.directory}/veracode/</outputDirectory>
                   <descriptors>
                     <descriptor>${veracode.descriptor}</descriptor>


### PR DESCRIPTION
Fix "user id is too big" when running maven assembly plugin