### PR TITLE
Removed deprecated cluster permission

### DIFF
--- a/src/main/java/com/floragunn/searchguard/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/com/floragunn/searchguard/privileges/PrivilegesEvaluator.java
@@ -611,7 +611,6 @@ public class PrivilegesEvaluator {
             || (action0.equals(MultiGetAction.NAME))
             || (action0.equals(MultiSearchAction.NAME))
             || (action0.equals(MultiTermVectorsAction.NAME))
-            || (action0.equals("indices:data/read/coordinate-msearch"))
             || (action0.equals(ReindexAction.NAME))
 
             ) ;


### PR DESCRIPTION
This is a old cluster level permission added for the siren-join plugin. This project is not maintained anymore and not compatible with Elasticsearch 5 & 6. This can be safely removed.