### PR TITLE
Don't allow anyone to freeze the searchguard index or update mapping,settings or aliases (ITT-1997)

### DIFF
--- a/src/main/java/com/floragunn/searchguard/privileges/SearchGuardIndexAccessEvaluator.java
+++ b/src/main/java/com/floragunn/searchguard/privileges/SearchGuardIndexAccessEvaluator.java
@@ -39,37 +39,35 @@ public class SearchGuardIndexAccessEvaluator {
     
     private final String searchguardIndex;
     private final AuditLog auditLog;
-    private final String[] sgDeniedActionPatternsAll;
-    private final String[] sgDeniedActionPatternsSnapshotRestoreAllowed;
-
-    private final boolean restoreSgIndexEnabled;
+    private final String[] sgDeniedActionPatterns;
     
     public SearchGuardIndexAccessEvaluator(final Settings settings, AuditLog auditLog) {
         this.searchguardIndex = settings.get(ConfigConstants.SEARCHGUARD_CONFIG_INDEX_NAME, ConfigConstants.SG_DEFAULT_CONFIG_INDEX);
         this.auditLog = auditLog;
         
-        final List<String> sgIndexdeniedActionPatternsListAll = new ArrayList<String>();
-        sgIndexdeniedActionPatternsListAll.add("indices:data/write*");
-        sgIndexdeniedActionPatternsListAll.add("indices:admin/close");
-        sgIndexdeniedActionPatternsListAll.add("indices:admin/delete");
-        sgIndexdeniedActionPatternsListAll.add("cluster:admin/snapshot/restore");
-
-        sgDeniedActionPatternsAll = sgIndexdeniedActionPatternsListAll.toArray(new String[0]);
-
-        final List<String> sgIndexdeniedActionPatternsListSnapshotRestoreAllowed = new ArrayList<String>();
-        sgIndexdeniedActionPatternsListAll.add("indices:data/write*");
-        sgIndexdeniedActionPatternsListAll.add("indices:admin/delete");
-              
-        sgDeniedActionPatternsSnapshotRestoreAllowed = sgIndexdeniedActionPatternsListSnapshotRestoreAllowed.toArray(new String[0]);
+        final boolean restoreSgIndexEnabled = settings.getAsBoolean(ConfigConstants.SEARCHGUARD_UNSUPPORTED_RESTORE_SGINDEX_ENABLED, false);
         
-        this.restoreSgIndexEnabled = settings.getAsBoolean(ConfigConstants.SEARCHGUARD_UNSUPPORTED_RESTORE_SGINDEX_ENABLED, false);
+        final List<String> sgIndexDeniedActionPatternsList = new ArrayList<String>();
+        sgIndexDeniedActionPatternsList.add("indices:data/write*");
+        sgIndexDeniedActionPatternsList.add("indices:admin/delete*");
+        sgIndexDeniedActionPatternsList.add("indices:admin/mapping/delete*");
+        sgIndexDeniedActionPatternsList.add("indices:admin/mapping/put*");
+        //sgIndexDeniedActionPatternsList.add("indices:admin/template/*");
+        sgIndexDeniedActionPatternsList.add("indices:admin/freeze*");
+        sgIndexDeniedActionPatternsList.add("indices:admin/settings/update*");
+        sgIndexDeniedActionPatternsList.add("indices:admin/aliases*");
+
+        final List<String> sgIndexDeniedActionPatternsListNoSnapshot = new ArrayList<String>();
+        sgIndexDeniedActionPatternsListNoSnapshot.addAll(sgIndexDeniedActionPatternsList);
+        sgIndexDeniedActionPatternsListNoSnapshot.add("indices:admin/close*");
+        sgIndexDeniedActionPatternsListNoSnapshot.add("cluster:admin/snapshot/restore*");
+
+        sgDeniedActionPatterns = (restoreSgIndexEnabled?sgIndexDeniedActionPatternsList:sgIndexDeniedActionPatternsListNoSnapshot).toArray(new String[0]);
     }
     
     public PrivilegesEvaluatorResponse evaluate(final ActionRequest request, final Task task, final String action, final Resolved requestedResolved,
             final PrivilegesEvaluatorResponse presponse)  {
-        
-        final String[] sgDeniedActionPatterns = this.restoreSgIndexEnabled? sgDeniedActionPatternsSnapshotRestoreAllowed : sgDeniedActionPatternsAll;
-        
+                
         if (requestedResolved.getAllIndices().contains(searchguardIndex)
                 && WildcardMatcher.matchAny(sgDeniedActionPatterns, action)) {
             auditLog.logSgIndexAttempt(request, action, task);

--- a/src/test/java/com/floragunn/searchguard/IntegrationTests.java
+++ b/src/test/java/com/floragunn/searchguard/IntegrationTests.java
@@ -819,5 +819,45 @@ public class IntegrationTests extends SingleClusterTest {
         Assert.assertEquals(HttpStatus.SC_OK, (resc=rh.executeGetRequest("*/_mapping/field/*", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode());
         System.out.println(resc.getBody());
     }
+    
+    @Test
+    public void testSgIndexSecurity() throws Exception {
+        setup();
+        final RestHelper rh = nonSslRestHelper();
+
+        HttpResponse res = rh.executePutRequest("searchguard/_mapping/sg?pretty", "{\"properties\": {\"name\":{\"type\":\"text\"}}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        res = rh.executePutRequest("*earc*gua*/_mapping/sg?pretty", "{\"properties\": {\"name\":{\"type\":\"text\"}}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        res = rh.executePutRequest("_mapping/sg?pretty", "{\"properties\": {\"name\":{\"type\":\"text\"}}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        res = rh.executePutRequest("*/_mapping/sg?pretty", "{\"properties\": {\"name\":{\"type\":\"text\"}}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        res = rh.executePutRequest("_all/_mapping/sg?pretty", "{\"properties\": {\"name\":{\"type\":\"text\"}}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        res = rh.executePostRequest("searchguard/_close", "",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        res = rh.executeDeleteRequest("searchguard",
+                encodeBasicHeader("nagilum", "nagilum"));
+        res = rh.executeDeleteRequest("_all",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        res = rh.executePutRequest("searchguard/_settings", "{\"index\" : {\"number_of_replicas\" : 2}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        res = rh.executePutRequest("searchgu*/_settings", "{\"index\" : {\"number_of_replicas\" : 2}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+//        res = rh.executePostRequest("searchguard/_freeze", "",
+//                encodeBasicHeader("nagilum", "nagilum"));
+//        Assert.assertTrue(res.getStatusCode() >= 400);
+
+    }
 
 }


### PR DESCRIPTION
Also fix a bug where "searchguard.unsupported.restore.sgindex.enabled" was not working correctly (ITT-2001)
