### PR TITLE
Fix index resolution for "*,-index" patterns, introduce searchguard.filter_sgindex_from_all_requests option (ITT-2263, ITT-1929)

### DIFF
--- a/src/main/java/com/floragunn/searchguard/SearchGuardPlugin.java
+++ b/src/main/java/com/floragunn/searchguard/SearchGuardPlugin.java
@@ -1022,6 +1022,9 @@ public final class SearchGuardPlugin extends SearchGuardSSLPlugin implements Clu
             settings.add(Setting.simpleString(ConfigConstants.SEARCHGUARD_COMPLIANCE_SALT, Property.NodeScope, Property.Filtered));
             settings.add(Setting.boolSetting(ConfigConstants.SEARCHGUARD_COMPLIANCE_HISTORY_INTERNAL_CONFIG_ENABLED, false, Property.NodeScope,
                     Property.Filtered));
+            
+            settings.add(Setting.boolSetting(ConfigConstants.SEARCHGUARD_FILTER_SGINDEX_FROM_ALL_REQUESTS, false, Property.NodeScope,
+                    Property.Filtered));
 
             //compat
             settings.add(Setting.boolSetting(ConfigConstants.SEARCHGUARD_UNSUPPORTED_DISABLE_INTERTRANSPORT_AUTH_INITIALLY, false, Property.NodeScope,

--- a/src/main/java/com/floragunn/searchguard/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/com/floragunn/searchguard/privileges/PrivilegesEvaluator.java
@@ -153,7 +153,7 @@ public class PrivilegesEvaluator implements ConfigurationChangeListener {
         configurationRepository.subscribeOnChange("rolesmapping", this);
         this.irr = irr;
         snapshotRestoreEvaluator = new SnapshotRestoreEvaluator(settings, auditLog);
-        sgIndexAccessEvaluator = new SearchGuardIndexAccessEvaluator(settings, auditLog);
+        sgIndexAccessEvaluator = new SearchGuardIndexAccessEvaluator(settings, auditLog, irr);
         dlsFlsEvaluator = new DlsFlsEvaluator(settings, threadPool);
         termsAggregationEvaluator = new TermsAggregationEvaluator();
         tenantHolder = new TenantHolder();

--- a/src/main/java/com/floragunn/searchguard/resolver/IndexResolverReplacer.java
+++ b/src/main/java/com/floragunn/searchguard/resolver/IndexResolverReplacer.java
@@ -133,12 +133,8 @@ public final class IndexResolverReplacer implements ConfigurationChangeListener 
     private static final boolean isLocalAll(final String... requestedPatterns) {
 
         final List<String> patterns = requestedPatterns==null?null:Arrays.asList(requestedPatterns);
-
+        
         if(IndexNameExpressionResolver.isAllIndices(patterns)) {
-            return true;
-        }
-
-        if(patterns.contains("*")) {
             return true;
         }
 

--- a/src/main/java/com/floragunn/searchguard/support/ConfigConstants.java
+++ b/src/main/java/com/floragunn/searchguard/support/ConfigConstants.java
@@ -228,6 +228,7 @@ public class ConfigConstants {
     public static final String SEARCHGUARD_RESTAPI_PASSWORD_VALIDATION_REGEX = "searchguard.restapi.password_validation_regex";
     public static final String SEARCHGUARD_RESTAPI_PASSWORD_VALIDATION_ERROR_MESSAGE = "searchguard.restapi.password_validation_error_message";
 
+    public static final String SEARCHGUARD_FILTER_SGINDEX_FROM_ALL_REQUESTS = "searchguard.filter_sgindex_from_all_requests";
 
     // Illegal Opcodes from here on
     public static final String SEARCHGUARD_UNSUPPORTED_RESTAPI_ACCEPT_INVALID_LICENSE = "searchguard.unsupported.restapi.accept_invalid_license";

--- a/src/test/java/com/floragunn/searchguard/IndexIntegrationTests.java
+++ b/src/test/java/com/floragunn/searchguard/IndexIntegrationTests.java
@@ -24,6 +24,7 @@ import java.util.TimeZone;
 import org.apache.http.HttpStatus;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.client.transport.TransportClient;
@@ -542,5 +543,50 @@ public class IndexIntegrationTests extends SingleClusterTest {
         HttpResponse resc = rh.executePostRequest("_msearch", msearchBody, encodeBasicHeader("worf", "worf"));
         Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("\"hits\":{\"total\":1"));
+    }
+    
+    @Test
+    //https://forum.search-guard.com/t/querying-missing-index-causes-security-exception/1531/11?u=hsaly
+    public void testIndexResolveIndicesAlias() throws Exception {
+
+        setup(Settings.EMPTY, new DynamicSgConfig(), Settings.EMPTY, true);
+        final RestHelper rh = nonSslRestHelper();
+
+        try (TransportClient tc = getInternalTransportClient()) {
+            //create indices and mapping upfront
+            tc.index(new IndexRequest("foo-index").type("_doc").setRefreshPolicy(RefreshPolicy.IMMEDIATE).source("{\"field2\":\"init\"}", XContentType.JSON)).actionGet();
+            tc.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(AliasActions.add().indices("foo-index").alias("foo-alias"))).actionGet();
+            tc.admin().indices().delete(new DeleteIndexRequest("foo-index")).actionGet();
+        }
+        
+        HttpResponse resc = rh.executeGetRequest("/_cat/aliases", encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertFalse(resc.getBody().contains("foo"));
+
+        resc = rh.executeGetRequest("/foo-alias/_search", encodeBasicHeader("foo_index", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        
+        resc = rh.executeGetRequest("/foo-index/_search", encodeBasicHeader("foo_index", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, resc.getStatusCode());
+        
+        resc = rh.executeGetRequest("/foo-alias/_search", encodeBasicHeader("foo_all", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, resc.getStatusCode());
+        
+    }
+    
+    @Test
+    //https://forum.search-guard.com/t/querying-missing-index-causes-security-exception/1531/11?u=hsaly
+    public void testIndexResolveMinus() throws Exception {
+
+        setup(Settings.EMPTY, new DynamicSgConfig(), Settings.EMPTY, true);
+        final RestHelper rh = nonSslRestHelper();
+
+        try (TransportClient tc = getInternalTransportClient()) {
+            //create indices and mapping upfront
+            tc.index(new IndexRequest("foo").type("_doc").setRefreshPolicy(RefreshPolicy.IMMEDIATE).source("{\"field2\":\"init\"}", XContentType.JSON)).actionGet();
+        }
+
+        HttpResponse resc = rh.executeGetRequest("/**,-foo/_search", encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        
     }
 }

--- a/src/test/java/com/floragunn/searchguard/IndexIntegrationTests.java
+++ b/src/test/java/com/floragunn/searchguard/IndexIntegrationTests.java
@@ -582,11 +582,38 @@ public class IndexIntegrationTests extends SingleClusterTest {
 
         try (TransportClient tc = getInternalTransportClient()) {
             //create indices and mapping upfront
-            tc.index(new IndexRequest("foo").type("_doc").setRefreshPolicy(RefreshPolicy.IMMEDIATE).source("{\"field2\":\"init\"}", XContentType.JSON)).actionGet();
+            tc.index(new IndexRequest("foo-abc").type("_doc").setRefreshPolicy(RefreshPolicy.IMMEDIATE).source("{\"field2\":\"init\"}", XContentType.JSON)).actionGet();
         }
 
-        HttpResponse resc = rh.executeGetRequest("/**,-foo/_search", encodeBasicHeader("nagilum", "nagilum"));
+        HttpResponse resc = rh.executeGetRequest("/**/_search", encodeBasicHeader("foo_all", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        
+        resc = rh.executeGetRequest("/*/_search", encodeBasicHeader("foo_all", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        
+        resc = rh.executeGetRequest("/_search", encodeBasicHeader("foo_all", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        
+        resc = rh.executeGetRequest("/**,-foo*/_search", encodeBasicHeader("foo_all", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        
+        resc = rh.executeGetRequest("/*,-foo*/_search", encodeBasicHeader("foo_all", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        
+        resc = rh.executeGetRequest("/**,-searchg*/_search", encodeBasicHeader("foo_all", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        
+        resc = rh.executeGetRequest("/*,-searchg*/_search", encodeBasicHeader("foo_all", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        
+        resc = rh.executeGetRequest("/*,-searchg*,-foo*/_search", encodeBasicHeader("foo_all", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        
+        resc = rh.executeGetRequest("/_all,-searchg*/_search", encodeBasicHeader("foo_all", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        
+        resc = rh.executeGetRequest("/_all,-searchg*/_search", encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, resc.getStatusCode());
         
     }
 }

--- a/src/test/java/com/floragunn/searchguard/IntegrationTests.java
+++ b/src/test/java/com/floragunn/searchguard/IntegrationTests.java
@@ -810,7 +810,10 @@ public class IntegrationTests extends SingleClusterTest {
 
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (resc=rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf"))).getStatusCode());
         System.out.println(resc.getBody());
-
+        
+        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, (resc=rh.executeGetRequest("_all,-indexb/_search?pretty", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode());
+        System.out.println(resc.getBody());
+        
         System.out.println("#### _all/_mapping/field/*");
         Assert.assertEquals(HttpStatus.SC_OK, (resc=rh.executeGetRequest("_all/_mapping/field/*", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode());
         System.out.println(resc.getBody());
@@ -826,8 +829,17 @@ public class IntegrationTests extends SingleClusterTest {
     public void testSgIndexSecurity() throws Exception {
         setup();
         final RestHelper rh = nonSslRestHelper();
+        
+        try (TransportClient tc = getInternalTransportClient()) {
+            tc.index(new IndexRequest("indexa").type("doc").id("0").setRefreshPolicy(RefreshPolicy.IMMEDIATE).source("{\"content\":\"indexa\"}", XContentType.JSON)).actionGet();
+        }
 
-        HttpResponse res = rh.executePutRequest("searchguard/_mapping/sg?pretty", "{\"properties\": {\"name\":{\"type\":\"text\"}}}",
+
+        HttpResponse res = rh.executePutRequest("searchguard,inde*/_mapping/doc?pretty", "{\"properties\": {\"name\":{\"type\":\"text\"}}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+
+        res = rh.executePutRequest("searchguard/_mapping/sg?pretty", "{\"properties\": {\"name\":{\"type\":\"text\"}}}",
                 encodeBasicHeader("nagilum", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
         res = rh.executePutRequest("*earc*gua*/_mapping/sg?pretty", "{\"properties\": {\"name\":{\"type\":\"text\"}}}",
@@ -847,7 +859,17 @@ public class IntegrationTests extends SingleClusterTest {
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
         res = rh.executeDeleteRequest("searchguard",
                 encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
         res = rh.executeDeleteRequest("_all",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        res = rh.executePutRequest("*/_settings", "{\"index\" : {\"number_of_replicas\" : 2}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        res = rh.executePutRequest("_settings", "{\"index\" : {\"number_of_replicas\" : 2}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        res = rh.executePutRequest("_all/_settings", "{\"index\" : {\"number_of_replicas\" : 2}}",
                 encodeBasicHeader("nagilum", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
         res = rh.executePutRequest("searchguard/_settings", "{\"index\" : {\"number_of_replicas\" : 2}}",
@@ -856,6 +878,82 @@ public class IntegrationTests extends SingleClusterTest {
         res = rh.executePutRequest("searchgu*/_settings", "{\"index\" : {\"number_of_replicas\" : 2}}",
                 encodeBasicHeader("nagilum", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        res = rh.executePutRequest("*,-searchguard/_settings", "{\"index\" : {\"number_of_replicas\" : 2}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        res = rh.executePutRequest("*,-searchguard,-index*/_settings", "{\"index\" : {\"number_of_replicas\" : 2}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, res.getStatusCode());
+//        res = rh.executePostRequest("searchguard/_freeze", "",
+//                encodeBasicHeader("nagilum", "nagilum"));
+//        Assert.assertTrue(res.getStatusCode() >= 400);
+
+    }
+    
+    @Test
+    public void testSgIndexSecurityWithSgIndexExcluded() throws Exception {
+        final Settings settings = Settings.builder()
+                .put(ConfigConstants.SEARCHGUARD_FILTER_SGINDEX_FROM_ALL_REQUESTS, true)
+                .build();
+
+        setup(Settings.EMPTY, new DynamicSgConfig(), settings);
+        
+        final RestHelper rh = nonSslRestHelper();
+        
+        try (TransportClient tc = getInternalTransportClient()) {
+            tc.index(new IndexRequest("indexa").type("doc").id("0").setRefreshPolicy(RefreshPolicy.IMMEDIATE).source("{\"content\":\"indexa\"}", XContentType.JSON)).actionGet();
+        }
+
+
+        HttpResponse res = rh.executePutRequest("searchguard,inde*/_mapping/doc?pretty", "{\"properties\": {\"name\":{\"type\":\"text\"}}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+
+        res = rh.executePutRequest("searchguard/_mapping/doc?pretty", "{\"properties\": {\"name\":{\"type\":\"text\"}}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        res = rh.executePutRequest("*earc*gua*/_mapping/doc?pretty", "{\"properties\": {\"name\":{\"type\":\"text\"}}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        res = rh.executePutRequest("_mapping/doc?pretty", "{\"properties\": {\"name\":{\"type\":\"text\"}}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        res = rh.executePutRequest("*/_mapping/doc?pretty", "{\"properties\": {\"name\":{\"type\":\"text\"}}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        res = rh.executePutRequest("_all/_mapping/doc?pretty", "{\"properties\": {\"name\":{\"type\":\"text\"}}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        res = rh.executePostRequest("searchguard/_close", "",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        res = rh.executeDeleteRequest("searchguard",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        res = rh.executePutRequest("*/_settings", "{\"index\" : {\"number_of_replicas\" : 2}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        res = rh.executePutRequest("_settings", "{\"index\" : {\"number_of_replicas\" : 2}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        res = rh.executePutRequest("_all/_settings", "{\"index\" : {\"number_of_replicas\" : 2}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        res = rh.executePutRequest("searchguard/_settings", "{\"index\" : {\"number_of_replicas\" : 2}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        res = rh.executePutRequest("searchgu*/_settings", "{\"index\" : {\"number_of_replicas\" : 2}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        res = rh.executePutRequest("*,-searchguard/_settings", "{\"index\" : {\"number_of_replicas\" : 2}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        res = rh.executePutRequest("*,-searchguard,-index*/_settings", "{\"index\" : {\"number_of_replicas\" : 2}}",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, res.getStatusCode());
+        res = rh.executeDeleteRequest("_all",
+                encodeBasicHeader("nagilum", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
 //        res = rh.executePostRequest("searchguard/_freeze", "",
 //                encodeBasicHeader("nagilum", "nagilum"));
 //        Assert.assertTrue(res.getStatusCode() >= 400);

--- a/src/test/resources/sg_internal_users.yml
+++ b/src/test/resources/sg_internal_users.yml
@@ -188,3 +188,10 @@ env.replace@example.comp.com:
   hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
   #password is: nagilum
   
+foo_index:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum
+  
+foo_all:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum

--- a/src/test/resources/sg_roles.yml
+++ b/src/test/resources/sg_roles.yml
@@ -543,3 +543,23 @@ sg_remote_ccs:
     '*':
       '*':
         - indices:admin/shards/search_shards
+        
+sg_role_foo_index:
+  cluster:
+    - '*'
+  indices:
+    'foo-index':
+      '*':
+        - indices:data/read/*
+        - indices:admin/*
+        - indices:monitor/*
+        
+sg_role_foo_all:
+  cluster:
+    - '*'
+  indices:
+    'foo-*':
+      '*':
+        - indices:data/read/*
+        - indices:admin/*
+        - indices:monitor/*

--- a/src/test/resources/sg_roles_mapping.yml
+++ b/src/test/resources/sg_roles_mapping.yml
@@ -172,3 +172,11 @@ sg_env_test:
 sg_remote_ccs:
   users:
     - crusherw
+    
+sg_role_foo_index:
+  users:
+    - foo_index
+    
+sg_role_foo_all:
+  users:
+    - foo_all


### PR DESCRIPTION
Introduce searchguard.filter_sgindex_from_all_requests which can be set to true in elasticsearch.yml (default is false) to filter out the searchguard index from _all or * requests referring to all indices.
In a later version we can change the default from "false" to "true".

Fix index resolution for patterns like "*,-index1" (ITT-2263, ITT-1929)